### PR TITLE
Adds output formatting layer (markdown / JSON / YAML)

### DIFF
--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -6,9 +6,15 @@ available data tiers, loads config, and produces a structured `AnalysisResult`.
 ## Public API
 
 ```ts
-import { quantify, detectCapabilities, loadConfig } from "@run2max/engine";
+import { quantify, formatResult, loadConfig, detectCapabilities } from "@run2max/engine";
 import type {
   AnalysisResult,
+  AnalysisMetadata,
+  FormatResult,
+  OutputFormat,
+  OutputProfileConfig,
+  SectionId,
+  ColumnId,
   Run2MaxConfig,
   DataCapabilities,
 } from "@run2max/engine";
@@ -30,7 +36,7 @@ const result = await quantify(buffer, {
 });
 ```
 
-> Not yet implemented — coming in Phase 3.
+`AnalysisResult` always includes a `metadata` field (`version`, `downsample`, `anomaliesExcluded`) populated from the options passed to `quantify()`.
 
 ### `loadConfig(options?)`
 
@@ -50,6 +56,34 @@ Resolution order (highest priority last):
 
 When both 1 and 2 exist, they are deep-merged: object fields merge, arrays
 replace.
+
+### `formatResult(result, format, profile)`
+
+Transforms an `AnalysisResult` into a formatted string. Returns `{ output, warnings }`.
+
+```ts
+import { formatResult, DEFAULT_PROFILE } from "@run2max/engine";
+
+const { output, warnings } = formatResult(result, "markdown", DEFAULT_PROFILE);
+// format: "markdown" | "json" | "yaml"
+```
+
+`DEFAULT_PROFILE` includes all sections and columns with `skipSegmentsIfSingleLap: false`.
+Pass a custom `OutputProfileConfig` to filter sections, restrict columns, or enable single-lap skipping.
+
+Warnings are returned (not thrown) when columns are dropped because the required data tier is
+unavailable, or when `skipSegmentsIfSingleLap` removes the segments section.
+
+**Sections:** `summary` · `segments` · `km_splits` · `zones` · `dynamics` · `anomalies`
+
+**Columns:** `power` · `zone` · `pace` · `hr` · `cadence` · `gct` · `gct_balance` · `stride` · `vo` · `vo_balance` · `fpr` · `vr`
+
+Column availability by tier:
+
+| Column(s) | Requires |
+|-----------|----------|
+| `gct`, `gct_balance`, `stride`, `vo`, `vo_balance`, `vr` | Tier 2 — Running Dynamics |
+| `fpr` | Tier 3 — Stryd-enhanced |
 
 ### `detectCapabilities(records)`
 
@@ -95,11 +129,11 @@ athlete:
 
 output:
   default:
-    sections: [summary, km_splits, zones, dynamics, notes]
+    sections: [summary, km_splits, zones, dynamics, anomalies]
     columns: [power, zone, pace, hr, cadence, gct, stride]
     skip_segments_if_single_lap: true
   detailed:
-    sections: [summary, segments, km_splits, zones, dynamics, notes]
+    sections: [summary, segments, km_splits, zones, dynamics, anomalies]
     columns: all
     skip_segments_if_single_lap: false
 ```

--- a/packages/engine/src/computations/quantify.ts
+++ b/packages/engine/src/computations/quantify.ts
@@ -12,6 +12,8 @@ import { computeKmSplits } from "./km-splits.js";
 import { computeZoneDistribution } from "./zones.js";
 import { computeDynamicsSummary } from "./dynamics.js";
 
+const ENGINE_VERSION = "0.0.1";
+
 /**
  * Main engine entry point. Takes a raw .fit file buffer and produces
  * a complete analysis result.
@@ -68,6 +70,11 @@ export async function quantify(
   const dynamicsSummary = computeDynamicsSummary(records, capabilities);
 
   return {
+    metadata: {
+      version: ENGINE_VERSION,
+      downsample: options.downsample ?? null,
+      anomaliesExcluded: options.excludeAnomalies ?? false,
+    },
     summary,
     segments,
     kmSplits,

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -33,9 +33,33 @@ const ZoneConfigSchema = v.object({
   rpe: v.optional(v.string()),
 });
 
+const SECTION_IDS = [
+  "summary",
+  "segments",
+  "km_splits",
+  "zones",
+  "dynamics",
+  "anomalies",
+] as const;
+
+const COLUMN_IDS = [
+  "power",
+  "zone",
+  "pace",
+  "hr",
+  "cadence",
+  "gct",
+  "gct_balance",
+  "stride",
+  "vo",
+  "vo_balance",
+  "fpr",
+  "vr",
+] as const;
+
 const OutputProfileConfigSchema = v.object({
-  sections: v.optional(v.array(v.string())),
-  columns: v.optional(v.union([v.array(v.string()), v.literal("all")])),
+  sections: v.optional(v.array(v.picklist(SECTION_IDS))),
+  columns: v.optional(v.union([v.array(v.picklist(COLUMN_IDS)), v.literal("all")])),
   skipSegmentsIfSingleLap: v.optional(v.boolean()),
 });
 

--- a/packages/engine/src/formatters/index.test.ts
+++ b/packages/engine/src/formatters/index.test.ts
@@ -1,0 +1,450 @@
+import { describe, it, expect } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type {
+  AnalysisResult,
+  SectionId,
+  ColumnId,
+} from "../types.js";
+import { formatResult, DEFAULT_PROFILE } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+const BASE_DATE = new Date("2026-04-12T08:20:00Z"); // Sunday in UTC
+
+function buildResult(overrides?: Partial<AnalysisResult>): AnalysisResult {
+  return {
+    metadata: {
+      version: "0.0.1",
+      downsample: null,
+      anomaliesExcluded: false,
+    },
+    summary: {
+      date: BASE_DATE,
+      timezone: "UTC",
+      duration: 7402,   // 2:03:22
+      movingTime: 7402,
+      distance: 18080,  // 18.08 km
+      avgPower: 224,
+      avgPowerZone: "E",
+      avgHeartRate: 140,
+      avgHeartRatePctLthr: 81.9,
+      avgPace: 409,     // 6:49/km
+      workout: "Recovery Run",
+      block: "Build Week 04",
+      rpe: 2,
+      notes: "Easy day.",
+    },
+    segments: [
+      {
+        lapIndex: 0,
+        distance: 9040,
+        duration: 3701,
+        avgPower: 220,
+        zone: "E",
+        avgPace: 410,
+        avgHeartRate: 138,
+        avgCadence: 83,
+        avgStanceTime: 350,
+        avgStanceTimeBalance: 49.8,
+        avgStepLength: 850,
+        avgVerticalOscillation: 47,
+        formPowerRatio: 0.34,
+        verticalRatio: 6.8,
+      },
+      {
+        lapIndex: 1,
+        distance: 9040,
+        duration: 3701,
+        avgPower: 228,
+        zone: "E",
+        avgPace: 408,
+        avgHeartRate: 142,
+        avgCadence: 84,
+        avgStanceTime: 348,
+        avgStanceTimeBalance: 49.9,
+        avgStepLength: 855,
+        avgVerticalOscillation: 46,
+        formPowerRatio: 0.33,
+        verticalRatio: 6.7,
+      },
+    ],
+    kmSplits: [
+      {
+        km: 1,
+        distance: 1000,
+        duration: 409,
+        avgPower: 222,
+        zone: "E",
+        avgPace: 409,
+        avgHeartRate: 139,
+        avgCadence: 83,
+        avgStanceTime: 350,
+        avgStanceTimeBalance: 49.8,
+        avgStepLength: 850,
+        avgVerticalOscillation: 47,
+        formPowerRatio: 0.34,
+        verticalRatio: 6.8,
+      },
+    ],
+    zoneDistribution: [
+      { label: "E", name: "Easy",     seconds: 7106, percentage: 96.0 },
+      { label: "M", name: "Marathon", seconds: 148,  percentage: 2.0  },
+      { label: "I", name: "Interval", seconds: 0,    percentage: 0.0  }, // must be omitted
+    ],
+    dynamicsSummary: {
+      avgStanceTime: 350,
+      avgStanceTimeBalance: 49.8,
+      avgStepLength: 850,
+      avgVerticalOscillation: 47,
+      avgVerticalOscillationBalance: 49.6,
+      avgFormPower: 62,
+      avgAirPower: 8,
+      avgLegSpringStiffness: 9.0,
+      avgLegSpringStiffnessBalance: 49.2,
+      avgFormPowerRatio: 0.34,
+      avgVerticalRatio: 6.8,
+    },
+    anomalies: [
+      {
+        type: "zero_value",
+        field: "heartRate",
+        description: "heartRate=0 for 10s at 0:00-0:09",
+        affectedRecords: 10,
+        excluded: false,
+      },
+      {
+        type: "zero_value",
+        field: "legSpringStiffness",
+        description: "legSpringStiffness=0 for 3s at 1:00-1:02",
+        affectedRecords: 3,
+        excluded: true,
+      },
+    ],
+    capabilities: {
+      hasRunningDynamics: true,
+      hasStrydEnhanced: true,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("formatResult", () => {
+  // ─── DEFAULT_PROFILE ──────────────────────────────────────────────────────
+
+  describe("DEFAULT_PROFILE", () => {
+    it("includes all sections in canonical order", () => {
+      expect(DEFAULT_PROFILE.sections).toEqual([
+        "summary",
+        "segments",
+        "km_splits",
+        "zones",
+        "dynamics",
+        "anomalies",
+      ]);
+    });
+
+    it("includes all columns", () => {
+      expect(DEFAULT_PROFILE.columns).toBe("all");
+    });
+
+    it("does not skip segments for single lap", () => {
+      expect(DEFAULT_PROFILE.skipSegmentsIfSingleLap).toBe(false);
+    });
+  });
+
+  // ─── MARKDOWN ─────────────────────────────────────────────────────────────
+
+  describe("markdown format", () => {
+    it("## Metadata appears first, before ## Run Summary", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      const metaIdx = output.indexOf("## Metadata");
+      const summaryIdx = output.indexOf("## Run Summary");
+      expect(metaIdx).toBeGreaterThanOrEqual(0);
+      expect(summaryIdx).toBeGreaterThan(metaIdx);
+      // Must be the very first content
+      expect(output.trimStart().startsWith("## Metadata")).toBe(true);
+    });
+
+    it("metadata renders version, downsample=none, anomalies=included", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      expect(output).toContain("run2max v0.0.1");
+      expect(output).toContain("none");
+      expect(output).toContain("included");
+    });
+
+    it("metadata renders downsample as Ns when set", () => {
+      const result = buildResult({
+        metadata: { version: "0.0.1", downsample: 5, anomaliesExcluded: true },
+      });
+      const { output } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      expect(output).toContain("5s");
+      expect(output).toContain("excluded");
+    });
+
+    it("null avgPower renders as -- in segment table", () => {
+      const result = buildResult();
+      result.segments[0]!.avgPower = null;
+      const { output } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      // Should contain at least one -- in the table rows
+      expect(output).toContain("--");
+    });
+
+    it("zone rows with 0% are omitted from Zone Distribution", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      expect(output).not.toContain("I (Interval)");
+      expect(output).toContain("E (Easy)");
+      expect(output).toContain("M (Marathon)");
+    });
+
+    it("excluded anomaly shows [EXCLUDED FROM STATS] prefix", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      expect(output).toContain("[EXCLUDED FROM STATS]");
+      expect(output).toContain("legSpringStiffness=0");
+    });
+
+    it("non-excluded anomaly has no [EXCLUDED FROM STATS] prefix", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      // The heartRate anomaly should appear without the prefix
+      const lines = output.split("\n");
+      const hrLine = lines.find(l => l.includes("heartRate=0"));
+      expect(hrLine).toBeDefined();
+      expect(hrLine).not.toContain("[EXCLUDED FROM STATS]");
+    });
+
+    it("shows HR % LTHR when avgHeartRatePctLthr is non-null", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      expect(output).toContain("% LTHR");
+    });
+
+    it("omits HR % LTHR when avgHeartRatePctLthr is null", () => {
+      const result = buildResult();
+      result.summary.avgHeartRatePctLthr = null;
+      const { output } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      expect(output).not.toContain("% LTHR");
+    });
+
+    it("omits context lines (Workout/Block/RPE/Notes) when not present", () => {
+      const result = buildResult();
+      delete result.summary.workout;
+      delete result.summary.block;
+      delete result.summary.rpe;
+      delete result.summary.notes;
+      const { output } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      expect(output).not.toContain("Workout:");
+      expect(output).not.toContain("Notes:");
+    });
+
+    it("pipe table rows have consistent column counts", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      // Find all pipe-table lines in the segments section
+      const lines = output.split("\n").filter(l => l.startsWith("|"));
+      // Group into contiguous blocks
+      let blockStart = 0;
+      while (blockStart < lines.length) {
+        // Count columns in first line of block
+        const expectedCols = lines[blockStart]!.split("|").length;
+        let blockEnd = blockStart + 1;
+        while (blockEnd < lines.length && lines[blockEnd]!.split("|").length === expectedCols) {
+          blockEnd++;
+        }
+        // All lines in this block should have the same column count
+        const block = lines.slice(blockStart, blockEnd);
+        const counts = block.map(l => l.split("|").length);
+        expect(new Set(counts).size).toBe(1);
+        blockStart = blockEnd;
+      }
+    });
+
+    it("renders zone in parentheses after power in Run Summary", () => {
+      const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
+      expect(output).toContain("224 W (E)");
+    });
+  });
+
+  // ─── PROFILE FILTERING: SECTIONS ──────────────────────────────────────────
+
+  describe("profile filtering — sections", () => {
+    it("only renders summary when sections=['summary']", () => {
+      const profile = { ...DEFAULT_PROFILE, sections: ["summary"] as SectionId[] };
+      const { output } = formatResult(buildResult(), "markdown", profile);
+      expect(output).toContain("## Run Summary");
+      expect(output).not.toContain("## Workout Splits");
+      expect(output).not.toContain("## Zone Distribution");
+      expect(output).not.toContain("## Running Dynamics");
+      expect(output).not.toContain("## Anomalies");
+    });
+
+    it("always includes ## Metadata even when not in sections", () => {
+      const profile = { ...DEFAULT_PROFILE, sections: ["summary"] as SectionId[] };
+      const { output } = formatResult(buildResult(), "markdown", profile);
+      expect(output).toContain("## Metadata");
+    });
+  });
+
+  // ─── PROFILE FILTERING: COLUMNS ───────────────────────────────────────────
+
+  describe("profile filtering — columns", () => {
+    it("only renders requested columns in Workout Splits table", () => {
+      const profile = {
+        ...DEFAULT_PROFILE,
+        columns: ["power", "pace"] as ColumnId[],
+      };
+      const { output } = formatResult(buildResult(), "markdown", profile);
+      expect(output).toContain("Power");
+      expect(output).toContain("Pace");
+      // HR and Cadence should not appear as table headers
+      const tableSection = output.slice(
+        output.indexOf("## Workout Splits"),
+        output.indexOf("\n## ", output.indexOf("## Workout Splits") + 1)
+      );
+      expect(tableSection).not.toContain("| HR");
+      expect(tableSection).not.toContain("| Cadence");
+    });
+  });
+
+  // ─── COLUMN RECONCILIATION ────────────────────────────────────────────────
+
+  describe("column reconciliation", () => {
+    it("drops tier-2 columns and warns when hasRunningDynamics=false", () => {
+      const result = buildResult({
+        capabilities: { hasRunningDynamics: false, hasStrydEnhanced: false },
+      });
+      const { warnings } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      // Should warn about at least one tier-2 column (e.g. gct)
+      const warnText = warnings.join(" ").toLowerCase();
+      expect(warnText).toMatch(/gct|stride|vo/);
+    });
+
+    it("drops fpr column and warns when hasStrydEnhanced=false", () => {
+      const result = buildResult({
+        capabilities: { hasRunningDynamics: true, hasStrydEnhanced: false },
+      });
+      const { warnings } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      const warnText = warnings.join(" ").toLowerCase();
+      expect(warnText).toContain("fpr");
+    });
+
+    it("drops zone column and warns when no zone distribution data", () => {
+      const result = buildResult({ zoneDistribution: [] });
+      const { warnings } = formatResult(result, "markdown", DEFAULT_PROFILE);
+      const warnText = warnings.join(" ").toLowerCase();
+      expect(warnText).toContain("zone");
+    });
+  });
+
+  // ─── SKIP SEGMENTS IF SINGLE LAP ──────────────────────────────────────────
+
+  describe("skipSegmentsIfSingleLap", () => {
+    it("omits Workout Splits when 1 segment and flag is true, adds warning", () => {
+      const profile = { ...DEFAULT_PROFILE, skipSegmentsIfSingleLap: true };
+      const result = buildResult({ segments: [buildResult().segments[0]!] });
+      const { output, warnings } = formatResult(result, "markdown", profile);
+      expect(output).not.toContain("## Workout Splits");
+      expect(warnings.some(w => w.toLowerCase().includes("segment"))).toBe(true);
+    });
+
+    it("keeps Workout Splits when 2 segments and flag is true", () => {
+      const profile = { ...DEFAULT_PROFILE, skipSegmentsIfSingleLap: true };
+      const { output } = formatResult(buildResult(), "markdown", profile);
+      expect(output).toContain("## Workout Splits");
+    });
+  });
+
+  // ─── JSON FORMAT ──────────────────────────────────────────────────────────
+
+  describe("json format", () => {
+    it("produces valid JSON", () => {
+      const { output } = formatResult(buildResult(), "json", DEFAULT_PROFILE);
+      expect(() => JSON.parse(output)).not.toThrow();
+    });
+
+    it("metadata key is always present with correct values", () => {
+      const { output } = formatResult(buildResult(), "json", DEFAULT_PROFILE);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed["metadata"]).toBeDefined();
+      const meta = parsed["metadata"] as Record<string, unknown>;
+      expect(meta["version"]).toBe("0.0.1");
+      expect(meta["downsample"]).toBeNull();
+      expect(meta["anomaliesExcluded"]).toBe(false);
+    });
+
+    it("omitted sections have no key in JSON output", () => {
+      const profile = { ...DEFAULT_PROFILE, sections: ["summary"] as SectionId[] };
+      const { output } = formatResult(buildResult(), "json", profile);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed["summary"]).toBeDefined();
+      expect(parsed["segments"]).toBeUndefined();
+      expect(parsed["zoneDistribution"]).toBeUndefined();
+    });
+
+    it("null row values serialize as null", () => {
+      const result = buildResult();
+      result.segments[0]!.avgPower = null;
+      const { output } = formatResult(result, "json", DEFAULT_PROFILE);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const segs = parsed["segments"] as Array<Record<string, unknown>>;
+      expect(segs[0]!["avgPower"]).toBeNull();
+    });
+
+    it("column-filtered rows include identity fields plus requested columns only", () => {
+      const profile = {
+        ...DEFAULT_PROFILE,
+        columns: ["power"] as ColumnId[],
+      };
+      const { output } = formatResult(buildResult(), "json", profile);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const segs = parsed["segments"] as Array<Record<string, unknown>>;
+      const seg = segs[0]!;
+      // Identity fields always present
+      expect(seg["lapIndex"]).toBeDefined();
+      expect(seg["distance"]).toBeDefined();
+      expect(seg["duration"]).toBeDefined();
+      // Requested column present
+      expect(seg["avgPower"]).toBeDefined();
+      // Other columns absent
+      expect(seg["avgHeartRate"]).toBeUndefined();
+      expect(seg["avgCadence"]).toBeUndefined();
+    });
+  });
+
+  // ─── YAML FORMAT ──────────────────────────────────────────────────────────
+
+  describe("yaml format", () => {
+    it("produces valid YAML", () => {
+      const { output } = formatResult(buildResult(), "yaml", DEFAULT_PROFILE);
+      expect(() => parseYaml(output)).not.toThrow();
+    });
+
+    it("metadata key is always present", () => {
+      const { output } = formatResult(buildResult(), "yaml", DEFAULT_PROFILE);
+      const parsed = parseYaml(output) as Record<string, unknown>;
+      expect(parsed["metadata"]).toBeDefined();
+    });
+
+    it("uses snake_case for camelCase keys", () => {
+      const { output } = formatResult(buildResult(), "yaml", DEFAULT_PROFILE);
+      const parsed = parseYaml(output) as Record<string, unknown>;
+      // avgPower → avg_power in segment rows
+      const segs = parsed["segments"] as Array<Record<string, unknown>>;
+      expect(segs[0]).toHaveProperty("avg_power");
+      expect(segs[0]).not.toHaveProperty("avgPower");
+      // zoneDistribution → zone_distribution at top level
+      expect(parsed).toHaveProperty("zone_distribution");
+      expect(parsed).not.toHaveProperty("zoneDistribution");
+    });
+
+    it("omitted sections have no key in YAML output", () => {
+      const profile = { ...DEFAULT_PROFILE, sections: ["summary"] as SectionId[] };
+      const { output } = formatResult(buildResult(), "yaml", profile);
+      const parsed = parseYaml(output) as Record<string, unknown>;
+      expect(parsed["summary"]).toBeDefined();
+      expect(parsed["segments"]).toBeUndefined();
+    });
+  });
+});

--- a/packages/engine/src/formatters/index.ts
+++ b/packages/engine/src/formatters/index.ts
@@ -121,6 +121,11 @@ function applyProfile(
 // formatResult — public entry point
 // ---------------------------------------------------------------------------
 
+/**
+ * Formats an AnalysisResult into markdown, JSON, or YAML.
+ * Profile controls which sections and columns are included.
+ * Returns { output, warnings } — warnings are non-fatal (e.g. dropped columns).
+ */
 export function formatResult(
   result: AnalysisResult,
   format: OutputFormat,

--- a/packages/engine/src/formatters/index.ts
+++ b/packages/engine/src/formatters/index.ts
@@ -1,0 +1,149 @@
+import type {
+  AnalysisResult,
+  AnalysisMetadata,
+  ColumnId,
+  DataCapabilities,
+  FormatResult,
+  OutputFormat,
+  RunSummary,
+  SegmentRow,
+  KmSplitRow,
+  ZoneDistributionRow,
+  DynamicsSummary,
+  Anomaly,
+  SectionId,
+} from "../types.js";
+import type { OutputProfileConfig } from "../config/schema.js";
+import { TIER_REQUIREMENTS } from "./utils.js";
+import { formatMarkdown } from "./markdown.js";
+import { formatJson } from "./json.js";
+import { formatYaml } from "./yaml.js";
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PROFILE: OutputProfileConfig = {
+  sections: ["summary", "segments", "km_splits", "zones", "dynamics", "anomalies"],
+  columns: "all",
+  skipSegmentsIfSingleLap: false,
+};
+
+const ALL_COLUMN_IDS: ColumnId[] = [
+  "power", "zone", "pace", "hr", "cadence",
+  "gct", "gct_balance", "stride", "vo", "vo_balance", "fpr", "vr",
+];
+
+// ---------------------------------------------------------------------------
+// Internal filtered result shape
+// ---------------------------------------------------------------------------
+
+interface FilteredResult {
+  metadata: AnalysisMetadata;
+  capabilities: DataCapabilities;
+  summary?: RunSummary;
+  segments?: SegmentRow[];
+  kmSplits?: KmSplitRow[];
+  zoneDistribution?: ZoneDistributionRow[];
+  dynamicsSummary?: DynamicsSummary | null;
+  anomalies?: Anomaly[];
+}
+
+// ---------------------------------------------------------------------------
+// reconcileColumns — drop columns that require unavailable capabilities
+// ---------------------------------------------------------------------------
+
+function reconcileColumns(
+  requested: ColumnId[] | "all",
+  caps: DataCapabilities,
+  zoneDistribution: ZoneDistributionRow[],
+): { columns: ColumnId[]; warnings: string[] } {
+  const candidates = requested === "all" ? [...ALL_COLUMN_IDS] : [...requested];
+  const columns: ColumnId[] = [];
+  const warnings: string[] = [];
+
+  for (const col of candidates) {
+    const requiredCap = TIER_REQUIREMENTS[col];
+    if (requiredCap && !caps[requiredCap]) {
+      warnings.push(`Column "${col}" dropped: requires ${requiredCap} (not available in this file)`);
+      continue;
+    }
+    if (col === "zone" && zoneDistribution.length === 0) {
+      warnings.push(`Column "zone" dropped: no zone configuration`);
+      continue;
+    }
+    columns.push(col);
+  }
+
+  return { columns, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// applyProfile — filter result to active sections; handle skipSegmentsIfSingleLap
+// ---------------------------------------------------------------------------
+
+function applyProfile(
+  result: AnalysisResult,
+  profile: OutputProfileConfig,
+): { filtered: FilteredResult; activeSections: SectionId[]; warnings: string[] } {
+  const allSections: SectionId[] = [
+    "summary", "segments", "km_splits", "zones", "dynamics", "anomalies",
+  ];
+  let activeSections: SectionId[] = profile.sections ?? allSections;
+  const warnings: string[] = [];
+
+  // skipSegmentsIfSingleLap
+  if (
+    profile.skipSegmentsIfSingleLap &&
+    result.segments.length <= 1 &&
+    activeSections.includes("segments")
+  ) {
+    activeSections = activeSections.filter(s => s !== "segments");
+    warnings.push("Segments section skipped: only one lap detected");
+  }
+
+  const filtered: FilteredResult = {
+    metadata: result.metadata,
+    capabilities: result.capabilities,
+  };
+
+  if (activeSections.includes("summary"))   filtered.summary = result.summary;
+  if (activeSections.includes("segments"))  filtered.segments = result.segments;
+  if (activeSections.includes("km_splits")) filtered.kmSplits = result.kmSplits;
+  if (activeSections.includes("zones"))     filtered.zoneDistribution = result.zoneDistribution;
+  if (activeSections.includes("dynamics"))  filtered.dynamicsSummary = result.dynamicsSummary;
+  if (activeSections.includes("anomalies")) filtered.anomalies = result.anomalies;
+
+  return { filtered, activeSections, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// formatResult — public entry point
+// ---------------------------------------------------------------------------
+
+export function formatResult(
+  result: AnalysisResult,
+  format: OutputFormat,
+  profile: OutputProfileConfig,
+): FormatResult {
+  const { filtered, activeSections, warnings: sectionWarnings } = applyProfile(result, profile);
+
+  const { columns, warnings: colWarnings } = reconcileColumns(
+    profile.columns ?? "all",
+    result.capabilities,
+    result.zoneDistribution,
+  );
+
+  const warnings = [...sectionWarnings, ...colWarnings];
+
+  let output: string;
+  if (format === "markdown") {
+    output = formatMarkdown(filtered, activeSections, columns);
+  } else if (format === "json") {
+    output = formatJson(filtered, columns);
+  } else {
+    output = formatYaml(filtered, columns);
+  }
+
+  return { output, warnings };
+}

--- a/packages/engine/src/formatters/json.ts
+++ b/packages/engine/src/formatters/json.ts
@@ -1,0 +1,52 @@
+import type { AnalysisResult, ColumnId, SegmentRow, KmSplitRow } from "../types.js";
+import { COLUMN_FIELD_MAP } from "./utils.js";
+
+type FilteredResult = Pick<
+  AnalysisResult,
+  "metadata" | "capabilities"
+> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">>;
+
+const SEGMENT_IDENTITY = ["lapIndex", "distance", "duration"] as const;
+const KM_IDENTITY = ["km", "distance", "duration"] as const;
+
+function filterSegmentRow(
+  row: SegmentRow,
+  activeColumns: ColumnId[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of SEGMENT_IDENTITY) result[key] = row[key];
+  for (const col of activeColumns) {
+    const field = COLUMN_FIELD_MAP[col];
+    result[field] = (row as Record<string, unknown>)[field] ?? null;
+  }
+  return result;
+}
+
+function filterKmRow(
+  row: KmSplitRow,
+  activeColumns: ColumnId[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of KM_IDENTITY) result[key] = row[key];
+  for (const col of activeColumns) {
+    const field = COLUMN_FIELD_MAP[col];
+    result[field] = (row as Record<string, unknown>)[field] ?? null;
+  }
+  return result;
+}
+
+export function formatJson(
+  filtered: FilteredResult,
+  activeColumns: ColumnId[],
+): string {
+  const out: Record<string, unknown> = { metadata: filtered.metadata };
+
+  if (filtered.summary !== undefined)   out["summary"] = filtered.summary;
+  if (filtered.segments !== undefined)  out["segments"] = filtered.segments.map(r => filterSegmentRow(r, activeColumns));
+  if (filtered.kmSplits !== undefined)  out["kmSplits"] = filtered.kmSplits.map(r => filterKmRow(r, activeColumns));
+  if (filtered.zoneDistribution !== undefined) out["zoneDistribution"] = filtered.zoneDistribution;
+  if (filtered.dynamicsSummary !== undefined)  out["dynamicsSummary"] = filtered.dynamicsSummary;
+  if (filtered.anomalies !== undefined) out["anomalies"] = filtered.anomalies;
+
+  return JSON.stringify(out, null, 2);
+}

--- a/packages/engine/src/formatters/markdown.ts
+++ b/packages/engine/src/formatters/markdown.ts
@@ -1,0 +1,240 @@
+import type {
+  AnalysisResult,
+  ColumnId,
+  SectionId,
+} from "../types.js";
+import type { OutputProfileConfig } from "../config/schema.js";
+import {
+  NULL_PLACEHOLDER,
+  COLUMN_HEADERS,
+  fmtDate,
+  fmtDistance,
+  fmtDuration,
+  fmtPace,
+  fmtPower,
+  fmtHR,
+  fmtHRpctLTHR,
+  fmtLSS,
+  fmtBalance,
+  fmtGCT,
+  fmtStride,
+  fmtVO,
+  fmtFPR,
+  fmtVR,
+  fmtZonePct,
+  renderColumnValue,
+  padTable,
+} from "./utils.js";
+
+// ---------------------------------------------------------------------------
+// Internal types (re-uses optional fields from FilteredAnalysisResult)
+// ---------------------------------------------------------------------------
+
+type FilteredResult = Pick<
+  AnalysisResult,
+  "metadata" | "capabilities"
+> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">>;
+
+// ---------------------------------------------------------------------------
+// Section renderers
+// ---------------------------------------------------------------------------
+
+function renderMetadata(result: FilteredResult): string {
+  const { version, downsample, anomaliesExcluded } = result.metadata;
+  const dsStr = downsample != null ? `${downsample}s` : "none";
+  const anomStr = anomaliesExcluded ? "excluded" : "included";
+  return [
+    "## Metadata",
+    "",
+    `Produced by: run2max v${version}`,
+    `Downsample: ${dsStr}`,
+    `Anomalies: ${anomStr}`,
+  ].join("\n");
+}
+
+function renderSummary(result: FilteredResult): string {
+  const s = result.summary;
+  if (!s) return "";
+
+  const lines: string[] = ["## Run Summary", ""];
+
+  // Date line
+  lines.push(`Date: ${fmtDate(s.date, s.timezone)}`);
+
+  // Context lines (only if present)
+  const contextParts: string[] = [];
+  if (s.workout) contextParts.push(`Workout: ${s.workout}`);
+  if (s.block)   contextParts.push(`Block: ${s.block}`);
+  if (s.rpe != null) contextParts.push(`RPE: ${s.rpe}`);
+  if (contextParts.length > 0) lines.push(contextParts.join(" | "));
+  if (s.notes) lines.push(`Notes: ${s.notes}`);
+
+  // Distance / duration
+  lines.push(
+    `Distance: ${fmtDistance(s.distance)} | Duration: ${fmtDuration(s.duration)} | Moving Time: ${fmtDuration(s.movingTime)}`
+  );
+
+  // Stats line
+  const powerStr = s.avgPower != null
+    ? `${fmtPower(s.avgPower)}${s.avgPowerZone ? ` (${s.avgPowerZone})` : ""}`
+    : NULL_PLACEHOLDER;
+
+  const hrParts: string[] = [];
+  if (s.avgHeartRate != null) hrParts.push(fmtHR(s.avgHeartRate));
+  if (s.avgHeartRatePctLthr != null) hrParts.push(fmtHRpctLTHR(s.avgHeartRatePctLthr));
+  const hrStr = hrParts.length > 0 ? hrParts.join(" (") + (hrParts.length > 1 ? ")" : "") : NULL_PLACEHOLDER;
+
+  const paceStr = s.avgPace != null ? fmtPace(s.avgPace) : NULL_PLACEHOLDER;
+
+  lines.push(`Avg Power: ${powerStr} | Avg HR: ${hrStr} | Avg Pace: ${paceStr}`);
+
+  return lines.join("\n");
+}
+
+function renderSegments(result: FilteredResult, activeColumns: ColumnId[]): string {
+  const segments = result.segments;
+  if (!segments || segments.length === 0) return "";
+
+  const headers = [
+    "Split",
+    "Distance",
+    "Duration",
+    ...activeColumns.map(c => COLUMN_HEADERS[c]),
+  ];
+
+  const rows = segments.map(seg => {
+    const row = seg as Record<string, unknown>;
+    return [
+      `Split ${(seg.lapIndex + 1)}`,
+      fmtDistance(seg.distance),
+      fmtDuration(seg.duration),
+      ...activeColumns.map(c => renderColumnValue(c, row)),
+    ];
+  });
+
+  return ["## Workout Splits", "", padTable(headers, rows)].join("\n");
+}
+
+function renderKmSplits(result: FilteredResult, activeColumns: ColumnId[]): string {
+  const splits = result.kmSplits;
+  if (!splits || splits.length === 0) return "";
+
+  const headers = [
+    "KM",
+    "Distance",
+    "Duration",
+    ...activeColumns.map(c => COLUMN_HEADERS[c]),
+  ];
+
+  const rows = splits.map(split => {
+    const row = split as Record<string, unknown>;
+    return [
+      String(split.km),
+      fmtDistance(split.distance),
+      fmtDuration(split.duration),
+      ...activeColumns.map(c => renderColumnValue(c, row)),
+    ];
+  });
+
+  return ["## Kilometer Splits", "", padTable(headers, rows)].join("\n");
+}
+
+function renderZones(result: FilteredResult): string {
+  const zones = result.zoneDistribution;
+  if (!zones || zones.length === 0) return "";
+
+  const nonZero = zones.filter(z => z.percentage > 0);
+  if (nonZero.length === 0) return "";
+
+  const headers = ["Zone", "Time", "%"];
+  const rows = nonZero.map(z => [
+    `${z.label} (${z.name})`,
+    fmtDuration(z.seconds),
+    fmtZonePct(z.percentage),
+  ]);
+
+  return ["## Zone Distribution", "", padTable(headers, rows)].join("\n");
+}
+
+function renderDynamics(result: FilteredResult): string {
+  const d = result.dynamicsSummary;
+  if (!d) return "";
+
+  const lines: string[] = ["## Running Dynamics", ""];
+
+  // Tier 2a: GCT
+  const t2a: string[] = [];
+  if (d.avgStanceTime != null)        t2a.push(`Avg GCT: ${fmtGCT(d.avgStanceTime)}`);
+  if (d.avgStanceTimeBalance != null) t2a.push(`GCT Balance: ${fmtBalance(d.avgStanceTimeBalance)}`);
+  if (t2a.length > 0) lines.push(t2a.join(" | "));
+
+  // Tier 2b: Stride, VO, VO Balance
+  const t2b: string[] = [];
+  if (d.avgStepLength != null)                  t2b.push(`Avg Stride: ${fmtStride(d.avgStepLength)}`);
+  if (d.avgVerticalOscillation != null)         t2b.push(`Avg VO: ${fmtVO(d.avgVerticalOscillation)}`);
+  if (d.avgVerticalOscillationBalance != null)  t2b.push(`VO Balance: ${fmtBalance(d.avgVerticalOscillationBalance)}`);
+  if (t2b.length > 0) lines.push(t2b.join(" | "));
+
+  // Tier 3a: Form Power, Air Power, FPR
+  const t3a: string[] = [];
+  if (d.avgFormPower != null)        t3a.push(`Avg Form Power: ${fmtPower(d.avgFormPower)}`);
+  if (d.avgAirPower != null)         t3a.push(`Avg Air Power: ${fmtPower(d.avgAirPower)}`);
+  if (d.avgFormPowerRatio != null)   t3a.push(`FPR: ${fmtFPR(d.avgFormPowerRatio)}`);
+  if (t3a.length > 0) lines.push(t3a.join(" | "));
+
+  // Tier 3b: LSS, LSS Balance, VR
+  const t3b: string[] = [];
+  if (d.avgLegSpringStiffness != null)        t3b.push(`Avg LSS: ${fmtLSS(d.avgLegSpringStiffness)}`);
+  if (d.avgLegSpringStiffnessBalance != null) t3b.push(`LSS Balance: ${fmtBalance(d.avgLegSpringStiffnessBalance)}`);
+  if (d.avgVerticalRatio != null)             t3b.push(`VR: ${fmtVR(d.avgVerticalRatio)}`);
+  if (t3b.length > 0) lines.push(t3b.join(" | "));
+
+  return lines.join("\n");
+}
+
+function renderAnomalies(result: FilteredResult): string {
+  const anomalies = result.anomalies;
+  if (!anomalies || anomalies.length === 0) return "";
+
+  const items = anomalies.map(a => {
+    const prefix = a.excluded ? "[EXCLUDED FROM STATS] " : "";
+    return `- ${prefix}${a.description}`;
+  });
+
+  return ["## Anomalies", "", ...items].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section dispatch
+// ---------------------------------------------------------------------------
+
+const SECTION_RENDERERS: Record<
+  SectionId,
+  (result: FilteredResult, activeColumns: ColumnId[]) => string
+> = {
+  summary:   (r) => renderSummary(r),
+  segments:  (r, cols) => renderSegments(r, cols),
+  km_splits: (r, cols) => renderKmSplits(r, cols),
+  zones:     (r) => renderZones(r),
+  dynamics:  (r) => renderDynamics(r),
+  anomalies: (r) => renderAnomalies(r),
+};
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export function formatMarkdown(
+  filtered: FilteredResult,
+  activeSections: SectionId[],
+  activeColumns: ColumnId[],
+): string {
+  const parts: string[] = [renderMetadata(filtered)];
+
+  for (const section of activeSections) {
+    const rendered = SECTION_RENDERERS[section](filtered, activeColumns);
+    if (rendered) parts.push(rendered);
+  }
+
+  return parts.join("\n\n");
+}

--- a/packages/engine/src/formatters/utils.ts
+++ b/packages/engine/src/formatters/utils.ts
@@ -1,0 +1,226 @@
+import type { ColumnId, DataCapabilities } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Null placeholder
+// ---------------------------------------------------------------------------
+
+export const NULL_PLACEHOLDER = "--";
+
+// ---------------------------------------------------------------------------
+// Column metadata
+// ---------------------------------------------------------------------------
+
+export const COLUMN_HEADERS: Record<ColumnId, string> = {
+  power:       "Power",
+  zone:        "Zone",
+  pace:        "Pace",
+  hr:          "HR",
+  cadence:     "Cadence",
+  gct:         "GCT",
+  gct_balance: "GCT Bal",
+  stride:      "Stride",
+  vo:          "VO",
+  vo_balance:  "VO Bal",
+  fpr:         "FPR",
+  vr:          "VR",
+};
+
+/** Which DataCapabilities flag a column requires. Undefined = always available. */
+export const TIER_REQUIREMENTS: Partial<Record<ColumnId, keyof DataCapabilities>> = {
+  gct:         "hasRunningDynamics",
+  gct_balance: "hasRunningDynamics",
+  stride:      "hasRunningDynamics",
+  vo:          "hasRunningDynamics",
+  vo_balance:  "hasRunningDynamics",
+  vr:          "hasRunningDynamics",
+  fpr:         "hasStrydEnhanced",
+};
+
+/** Maps ColumnId to the field name on SegmentRow / KmSplitRow. */
+export const COLUMN_FIELD_MAP: Record<ColumnId, string> = {
+  power:       "avgPower",
+  zone:        "zone",
+  pace:        "avgPace",
+  hr:          "avgHeartRate",
+  cadence:     "avgCadence",
+  gct:         "avgStanceTime",
+  gct_balance: "avgStanceTimeBalance",
+  stride:      "avgStepLength",
+  vo:          "avgVerticalOscillation",
+  vo_balance:  "avgVerticalOscillationBalance",
+  fpr:         "formPowerRatio",
+  vr:          "verticalRatio",
+};
+
+// ---------------------------------------------------------------------------
+// Unit formatters
+// ---------------------------------------------------------------------------
+
+export function fmtDistance(m: number): string {
+  return `${(m / 1000).toFixed(2)} km`;
+}
+
+export function fmtDuration(s: number): string {
+  const totalSec = Math.round(s);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const sec = totalSec % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(sec).padStart(2, "0");
+  return `${h}:${mm}:${ss}`;
+}
+
+export function fmtPace(secPerKm: number): string {
+  const total = Math.round(secPerKm);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, "0")}/km`;
+}
+
+export function fmtPower(w: number): string {
+  return `${Math.round(w)} W`;
+}
+
+export function fmtHR(bpm: number): string {
+  return `${Math.round(bpm)} bpm`;
+}
+
+export function fmtHRpctLTHR(pct: number): string {
+  return `${pct.toFixed(1)} % LTHR`;
+}
+
+export function fmtCadence(spm: number): string {
+  return `${Math.round(spm)} spm`;
+}
+
+export function fmtGCT(ms: number): string {
+  return `${Math.round(ms)} ms`;
+}
+
+export function fmtBalance(pct: number): string {
+  return `${pct.toFixed(1)} %`;
+}
+
+/** stepLength is stored in mm; renders as m */
+export function fmtStride(mm: number): string {
+  return `${(mm / 1000).toFixed(2)} m`;
+}
+
+export function fmtVO(mm: number): string {
+  return `${Math.round(mm)} mm`;
+}
+
+export function fmtLSS(kNm: number): string {
+  return `${kNm.toFixed(1)} kN/m`;
+}
+
+export function fmtFPR(ratio: number): string {
+  return ratio.toFixed(2);
+}
+
+export function fmtVR(pct: number): string {
+  return `${pct.toFixed(1)} %`;
+}
+
+export function fmtZonePct(pct: number): string {
+  return `${pct.toFixed(1)} %`;
+}
+
+/** Format a Date in the given IANA timezone. */
+export function fmtDate(date: Date, timezone: string): string {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: timezone,
+  });
+  const parts = fmt.formatToParts(date);
+  const get = (type: string) => parts.find(p => p.type === type)?.value ?? "";
+  return `${get("weekday")}, ${get("month")} ${get("day")}, ${get("year")} ${get("hour")}:${get("minute")} (${timezone})`;
+}
+
+// ---------------------------------------------------------------------------
+// Column value renderer (used by markdown row cells)
+// ---------------------------------------------------------------------------
+
+export function renderColumnValue(
+  col: ColumnId,
+  row: Record<string, unknown>,
+): string {
+  const field = COLUMN_FIELD_MAP[col];
+  const value = row[field];
+  if (value === null || value === undefined) return NULL_PLACEHOLDER;
+  if (col === "zone") return String(value);
+  const n = value as number;
+  switch (col) {
+    case "power":       return fmtPower(n);
+    case "pace":        return fmtPace(n);
+    case "hr":          return fmtHR(n);
+    case "cadence":     return fmtCadence(n);
+    case "gct":         return fmtGCT(n);
+    case "gct_balance": return fmtBalance(n);
+    case "stride":      return fmtStride(n);
+    case "vo":          return fmtVO(n);
+    case "vo_balance":  return fmtBalance(n);
+    case "fpr":         return fmtFPR(n);
+    case "vr":          return fmtVR(n);
+    default:            return String(value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipe table builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a padded markdown pipe table.
+ * First column is left-aligned; all others are right-aligned.
+ */
+export function padTable(headers: string[], rows: string[][]): string {
+  const allRows = [headers, ...rows];
+  const colWidths = headers.map((_, colIdx) =>
+    Math.max(...allRows.map(row => (row[colIdx] ?? "").length), 3)
+  );
+
+  const padCell = (s: string, width: number, isFirst: boolean) =>
+    isFirst ? s.padEnd(width) : s.padStart(width);
+
+  const renderRow = (cells: string[]) =>
+    "| " +
+    cells.map((cell, i) => padCell(cell, colWidths[i]!, i === 0)).join(" | ") +
+    " |";
+
+  const separator =
+    "| " +
+    colWidths
+      .map((w, i) =>
+        i === 0
+          ? ":" + "-".repeat(w - 1)
+          : "-".repeat(w - 1) + ":"
+      )
+      .join(" | ") +
+    " |";
+
+  return [renderRow(headers), separator, ...rows.map(renderRow)].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// camelCase → snake_case (recursive, for YAML output)
+// ---------------------------------------------------------------------------
+
+export function camelToSnake(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(camelToSnake);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k.replace(/([A-Z])/g, "_$1").toLowerCase(),
+        camelToSnake(v),
+      ])
+    );
+  }
+  return value;
+}

--- a/packages/engine/src/formatters/yaml.ts
+++ b/packages/engine/src/formatters/yaml.ts
@@ -1,0 +1,53 @@
+import { stringify } from "yaml";
+import type { AnalysisResult, ColumnId, SegmentRow, KmSplitRow } from "../types.js";
+import { COLUMN_FIELD_MAP, camelToSnake } from "./utils.js";
+
+type FilteredResult = Pick<
+  AnalysisResult,
+  "metadata" | "capabilities"
+> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">>;
+
+const SEGMENT_IDENTITY = ["lapIndex", "distance", "duration"] as const;
+const KM_IDENTITY = ["km", "distance", "duration"] as const;
+
+function filterSegmentRow(
+  row: SegmentRow,
+  activeColumns: ColumnId[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of SEGMENT_IDENTITY) result[key] = row[key];
+  for (const col of activeColumns) {
+    const field = COLUMN_FIELD_MAP[col];
+    result[field] = (row as Record<string, unknown>)[field] ?? null;
+  }
+  return result;
+}
+
+function filterKmRow(
+  row: KmSplitRow,
+  activeColumns: ColumnId[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of KM_IDENTITY) result[key] = row[key];
+  for (const col of activeColumns) {
+    const field = COLUMN_FIELD_MAP[col];
+    result[field] = (row as Record<string, unknown>)[field] ?? null;
+  }
+  return result;
+}
+
+export function formatYaml(
+  filtered: FilteredResult,
+  activeColumns: ColumnId[],
+): string {
+  const out: Record<string, unknown> = { metadata: filtered.metadata };
+
+  if (filtered.summary !== undefined)   out["summary"] = filtered.summary;
+  if (filtered.segments !== undefined)  out["segments"] = filtered.segments.map(r => filterSegmentRow(r, activeColumns));
+  if (filtered.kmSplits !== undefined)  out["kmSplits"] = filtered.kmSplits.map(r => filterKmRow(r, activeColumns));
+  if (filtered.zoneDistribution !== undefined) out["zoneDistribution"] = filtered.zoneDistribution;
+  if (filtered.dynamicsSummary !== undefined)  out["dynamicsSummary"] = filtered.dynamicsSummary;
+  if (filtered.anomalies !== undefined) out["anomalies"] = filtered.anomalies;
+
+  return stringify(camelToSnake(out));
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -44,3 +44,16 @@ export { computeKmSplits } from "./computations/km-splits.js";
 export { computeDynamicsSummary } from "./computations/dynamics.js";
 export { computeSummary } from "./computations/summary.js";
 export { detectAnomalies, applyAnomalyExclusions } from "./computations/anomalies.js";
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+export { formatResult, DEFAULT_PROFILE } from "./formatters/index.js";
+export type {
+  FormatResult,
+  OutputFormat,
+  SectionId,
+  ColumnId,
+  AnalysisMetadata,
+} from "./types.js";

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -153,6 +153,7 @@ export interface Anomaly {
 }
 
 export interface AnalysisResult {
+  metadata: AnalysisMetadata;
   summary: RunSummary;
   segments: SegmentRow[];
   kmSplits: KmSplitRow[];
@@ -160,4 +161,43 @@ export interface AnalysisResult {
   dynamicsSummary: DynamicsSummary | null; // null when no Tier 2/3 data
   anomalies: Anomaly[];
   capabilities: DataCapabilities;
+}
+
+// ---------------------------------------------------------------------------
+// Formatter types
+// ---------------------------------------------------------------------------
+
+export type SectionId =
+  | "summary"
+  | "segments"
+  | "km_splits"
+  | "zones"
+  | "dynamics"
+  | "anomalies";
+
+export type ColumnId =
+  | "power"
+  | "zone"
+  | "pace"
+  | "hr"
+  | "cadence"
+  | "gct"
+  | "gct_balance"
+  | "stride"
+  | "vo"
+  | "vo_balance"
+  | "fpr"
+  | "vr";
+
+export type OutputFormat = "markdown" | "json" | "yaml";
+
+export interface AnalysisMetadata {
+  version: string;
+  downsample: number | null;
+  anomaliesExcluded: boolean;
+}
+
+export interface FormatResult {
+  output: string;
+  warnings: string[];
 }


### PR DESCRIPTION
  Adds a formatResult() function that transforms an AnalysisResult into human-readable output in
  three formats.
  
  - Profile-based filtering — OutputProfileConfig controls which sections (summary, segments, km
  splits, zones, dynamics, anomalies) and columns are included in the output
  - Column reconciliation — automatically drops columns that require unavailable data tiers (e.g.
  GCT requires running dynamics, FPR requires Stryd) and returns warnings
  - skipSegmentsIfSingleLap flag — omits the Workout Splits section when there's only one lap, with
  a warning
  - Markdown renderer — padded pipe tables for splits/zones, key-value pairs for dynamics,
  ##Metadata always first
  - JSON renderer — profile-filtered structure; omitted sections absent from object; column-filtered
   rows keep identity fields
  - YAML renderer — same filtering as JSON, all keys converted to snake_case
  - AnalysisMetadata field added to AnalysisResult — populated by quantify() with engine version,
  downsample rate, and anomaly exclusion flag
  - Schema tightened — sections and columns in OutputProfileConfig now validated with v.picklist()
  instead of freeform strings
  - 32 new tests written TDD-first, covering all formatter behaviors, edge cases, and format
  correctness
