### PR TITLE
Feature/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,61 @@
 # run2max
 
-CLI tool that takes a Stryd `.fit` file and produces a structured markdown analysis of a run.
+Structured run analysis from `.fit` files. Takes a Stryd `.fit` file and
+produces a clean markdown (or JSON/YAML) analysis.
 
 ```bash
-run2max quantify run.fit
+run2max quantify my-run.fit
 ```
+
+## Packages
+
+| Package                              | Description                          |
+| ------------------------------------ | ------------------------------------ |
+| [`@run2max/cli`](packages/cli)       | User-facing CLI — `run2max quantify` |
+| [`@run2max/engine`](packages/engine) | Core analysis library                |
+
+## Quick start
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build all packages
+pnpm build
+
+# Analyze a run
+run2max quantify my-run.fit
+```
+
+See [`packages/cli/README.md`](packages/cli/README.md) for the full CLI
+reference including flags, config, and output format.
 
 ## Monorepo structure
 
 ```
 packages/
-  engine/   @run2max/engine — core analysis library
-  cli/      @run2max/cli    — user-facing CLI (run2max quantify)
-fixture-fits/               — gitignored; drop .fit files here for smoke tests
+  engine/       @run2max/engine — core analysis library
+  cli/          @run2max/cli    — user-facing CLI (run2max quantify)
+fixture-fits/                   — gitignored; drop .fit files here for smoke tests
 ```
 
 ## Development
 
 ```bash
+# Install
 pnpm install
-pnpm --filter @run2max/engine build
-pnpm --filter @run2max/engine exec vitest run
+
+# Build all packages
+pnpm build
+
+# Run all tests (unit tests only)
+pnpm test
+
+# Run tests including smoke tests against a real .fit file
+FIT_FIXTURE=./fixture-fits/your-run.fit pnpm test
+
+# Build and watch
+pnpm dev
 ```
 
-Smoke tests against a real `.fit` file:
-
-```bash
-FIT_FIXTURE=./fixture-fits/your-run.fit pnpm --filter @run2max/engine exec vitest run
-```
+**Requirements:** Node 22 LTS or later, pnpm.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,193 @@
+# @run2max/cli
+
+CLI for run2max. Parses a Stryd `.fit` file and produces a structured analysis
+as markdown, JSON, or YAML.
+
+## Installation
+
+```bash
+pnpm install
+pnpm build
+```
+
+The `run2max` binary is available at `packages/cli/dist/index.js`. Link it
+globally with:
+
+```bash
+pnpm --filter @run2max/cli link --global
+```
+
+## Usage
+
+```bash
+run2max quantify <file.fit> [options]
+```
+
+### Basic
+
+```bash
+run2max quantify my-run.fit
+```
+
+Reads config from `~/.config/run2max/config.yaml` automatically and writes
+markdown to stdout.
+
+### With context metadata
+
+```bash
+run2max quantify my-run.fit \
+  --workout "Build 17: Recovery Run" \
+  --block "Build Week 04" \
+  --rpe 2 \
+  --notes "Felt easy throughout."
+```
+
+### Output format
+
+```bash
+run2max quantify my-run.fit --format md      # default: structured markdown
+run2max quantify my-run.fit --format json
+run2max quantify my-run.fit --format yaml
+```
+
+### Output profile
+
+Profiles are defined in your config file (see below). The `default` profile is
+used automatically if one is configured.
+
+```bash
+run2max quantify my-run.fit --profile detailed
+```
+
+### Write to file
+
+```bash
+run2max quantify my-run.fit --output analysis.md
+run2max quantify my-run.fit --format json --output analysis.json
+```
+
+### Timezone override
+
+```bash
+run2max quantify my-run.fit --timezone America/Santiago
+```
+
+Overrides both the config timezone and whatever timezone is embedded in the
+`.fit` file.
+
+### Downsampling
+
+```bash
+run2max quantify my-run.fit --downsample 10   # 1 record per 10 seconds
+```
+
+Reduces record density before all computations. Minimum value is 2.
+
+### Anomaly handling
+
+```bash
+run2max quantify my-run.fit --exclude-anomalies
+```
+
+By default, anomalies (HR=0, LSS=0 clusters) are detected and noted in the
+output but included in all calculations. With `--exclude-anomalies`, affected
+field values are nulled out and excluded from aggregations.
+
+### Explicit config file
+
+```bash
+run2max quantify my-run.fit --config ./run2max.config.yaml
+```
+
+Bypasses the auto-discovery order and uses the specified file directly.
+
+## All flags
+
+| Flag                  | Short | Default | Description                                |
+| --------------------- | ----- | ------- | ------------------------------------------ |
+| `--workout`           | `-w`  | —       | Workout name                               |
+| `--block`             | `-b`  | —       | Training block label                       |
+| `--rpe`               | —     | —       | Rating of Perceived Exertion (number)      |
+| `--notes`             | `-n`  | —       | Free-text notes                            |
+| `--format`            | `-f`  | `md`    | Output format: `md`, `json`, `yaml`        |
+| `--profile`           | `-p`  | —       | Output profile from config                 |
+| `--output`            | `-o`  | —       | Write to file instead of stdout            |
+| `--timezone`          | `-t`  | —       | IANA timezone override                     |
+| `--downsample`        | `-d`  | —       | Downsample interval in seconds (min 2)     |
+| `--config`            | `-c`  | —       | Explicit config file path                  |
+| `--exclude-anomalies` | —     | `false` | Exclude anomalous values from aggregations |
+
+## Config
+
+The CLI reads config automatically — no flag needed. Resolution order (highest
+priority last):
+
+1. `~/.config/run2max/config.yaml`
+2. `./run2max.config.yaml` (current working directory)
+3. `--config <path>` (bypasses auto-discovery)
+
+When both 1 and 2 exist they are deep-merged: object fields merge, arrays
+replace.
+
+### Config format
+
+```yaml
+calibration:
+  date: "2026-02-01"
+  source: "RECON block"
+  critical_power: 295
+  lthr: 171
+
+zones:
+  - { label: "E", name: "Easy", min: 204, max: 233, rpe: "2-4" }
+  - { label: "M", name: "Marathon", min: 251, max: 260, rpe: "5-6" }
+  - { label: "SS", name: "Sweet Spot", min: 260, max: 269, rpe: "6" }
+  - { label: "HM", name: "Half Marathon", min: 269, max: 280, rpe: "6-7" }
+  - { label: "SUB-T", name: "Sub-Threshold", min: 280, max: 289, rpe: "7" }
+  - { label: "THRESH", name: "Threshold", min: 289, max: 301, rpe: "7-8" }
+
+thresholds:
+  lthr: 171
+  max_hr: 192
+
+athlete:
+  timezone: "America/Santiago"
+
+output:
+  default:
+    sections: [summary, km_splits, zones, dynamics, anomalies]
+    columns: [power, zone, pace, hr, cadence, gct, stride]
+    skip_segments_if_single_lap: true
+  detailed:
+    sections: [summary, segments, km_splits, zones, dynamics, anomalies]
+    columns: all
+    skip_segments_if_single_lap: false
+```
+
+Only `zones` is required. All other fields are optional.
+
+If no config file is found, zone analysis is unavailable and a warning is
+printed to stderr. The rest of the output (km splits, dynamics, anomalies)
+is still produced.
+
+### Output profiles
+
+A profile controls which sections and columns appear in the output.
+
+**`sections`** — any subset of: `summary`, `segments`, `km_splits`, `zones`,
+`dynamics`, `anomalies`
+
+**`columns`** — any subset of the columns below, or `all`:
+
+| Column                                                   | Requires                  |
+| -------------------------------------------------------- | ------------------------- |
+| `power`, `zone`, `pace`, `hr`, `cadence`                 | Tier 1 (universal)        |
+| `gct`, `gct_balance`, `stride`, `vo`, `vo_balance`, `vr` | Tier 2 — Running Dynamics |
+| `fpr`                                                    | Tier 3 — Stryd-enhanced   |
+
+Columns that require a data tier not present in the `.fit` file are silently
+dropped with a warning printed to stderr.
+
+**`skip_segments_if_single_lap`** — when `true`, the segments section is
+omitted if the file has only one lap. Useful for the default profile to avoid a
+redundant one-row table.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@run2max/cli",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "type": "module",
   "bin": {
     "run2max": "./dist/index.js"

--- a/packages/cli/src/commands/quantify.ts
+++ b/packages/cli/src/commands/quantify.ts
@@ -1,4 +1,32 @@
 import { defineCommand } from "citty";
+import { readFile, writeFile } from "node:fs/promises";
+import {
+  loadConfig,
+  quantify,
+  formatResult,
+  DEFAULT_PROFILE,
+} from "@run2max/engine";
+import type { OutputFormat, OutputProfileConfig } from "@run2max/engine";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fatal(message: string): never {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function toArrayBuffer(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  ) as ArrayBuffer;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
 
 export default defineCommand({
   meta: {
@@ -11,9 +39,184 @@ export default defineCommand({
       description: "Path to the .fit file",
       required: true,
     },
+    workout: {
+      type: "string",
+      alias: "w",
+      description: "Workout name (e.g. 'Build 17: Recovery Run')",
+    },
+    block: {
+      type: "string",
+      alias: "b",
+      description: "Training block (e.g. 'Build Week 04')",
+    },
+    rpe: {
+      type: "string",
+      description: "Rating of Perceived Exertion",
+    },
+    notes: {
+      type: "string",
+      alias: "n",
+      description: "Free-text notes for this run",
+    },
+    format: {
+      type: "string",
+      alias: "f",
+      default: "md",
+      description: "Output format: md (default), json, yaml",
+    },
+    profile: {
+      type: "string",
+      alias: "p",
+      description: "Output profile name defined in config (e.g. default, detailed)",
+    },
+    output: {
+      type: "string",
+      alias: "o",
+      description: "Write output to file instead of stdout",
+    },
+    timezone: {
+      type: "string",
+      alias: "t",
+      description: "IANA timezone override (e.g. America/Santiago)",
+    },
+    downsample: {
+      type: "string",
+      alias: "d",
+      description: "Downsample interval in seconds (minimum 2)",
+    },
+    config: {
+      type: "string",
+      alias: "c",
+      description: "Explicit path to config file",
+    },
+    "exclude-anomalies": {
+      type: "boolean",
+      default: false,
+      description: "Exclude anomalous records from aggregations",
+    },
   },
-  run({ args }) {
-    console.log(`Analyzing: ${args.file}`);
-    console.log("Not yet implemented — coming in Phase 2.");
+
+  async run({ args }) {
+    // ---- Validate --format
+    const formatMap: Record<string, OutputFormat> = {
+      md: "markdown",
+      json: "json",
+      yaml: "yaml",
+    };
+    const formatKey = args.format ?? "md";
+    if (!(formatKey in formatMap)) {
+      fatal(`Invalid format "${formatKey}". Valid options: md, json, yaml`);
+    }
+    const format: OutputFormat = formatMap[formatKey]!;
+
+    // ---- Validate --timezone
+    if (args.timezone) {
+      const validTimezones = new Set(Intl.supportedValuesOf("timeZone"));
+      if (!validTimezones.has(args.timezone)) {
+        fatal(
+          `Invalid timezone "${args.timezone}". Use an IANA timezone name (e.g. America/Santiago)`,
+        );
+      }
+    }
+
+    // ---- Validate --downsample
+    let downsample: number | undefined;
+    if (args.downsample !== undefined) {
+      const parsed = Number(args.downsample);
+      if (isNaN(parsed) || parsed < 2) {
+        fatal(`--downsample must be at least 2 (seconds)`);
+      }
+      downsample = parsed;
+    }
+
+    // ---- Validate --rpe
+    let rpe: number | undefined;
+    if (args.rpe !== undefined) {
+      const parsed = Number(args.rpe);
+      if (isNaN(parsed)) {
+        fatal(`--rpe must be a number`);
+      }
+      rpe = parsed;
+    }
+
+    // ---- Read .fit file
+    let fileBuffer: Buffer;
+    try {
+      fileBuffer = await readFile(args.file);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        fatal(`File not found: ${args.file}`);
+      }
+      fatal(`Could not read file "${args.file}": ${(err as Error).message}`);
+    }
+    const fitBuffer = toArrayBuffer(fileBuffer);
+
+    // ---- Load config
+    let config;
+    try {
+      config = await loadConfig({ configPath: args.config });
+    } catch (err) {
+      fatal((err as Error).message);
+    }
+
+    if (config === null) {
+      console.error(
+        `Warning: No config found at ~/.config/run2max/config.yaml — zone analysis will be unavailable`,
+      );
+    }
+
+    // ---- Resolve output profile
+    let outputProfile: OutputProfileConfig = DEFAULT_PROFILE;
+    if (args.profile) {
+      const profileName = args.profile as "default" | "detailed" | string;
+      const configProfile = config?.output?.[profileName as keyof typeof config.output];
+      if (configProfile) {
+        outputProfile = configProfile;
+      } else {
+        console.error(
+          `Warning: Profile "${args.profile}" not found in config — using default profile`,
+        );
+      }
+    } else if (config?.output?.default) {
+      outputProfile = config.output.default;
+    }
+
+    // ---- Resolve timezone
+    const timezone = args.timezone ?? config?.athlete?.timezone;
+
+    // ---- Run analysis
+    let result;
+    try {
+      result = await quantify(fitBuffer, {
+        config: config ?? undefined,
+        workout: args.workout,
+        block: args.block,
+        rpe,
+        notes: args.notes,
+        timezone,
+        downsample,
+        excludeAnomalies: args["exclude-anomalies"],
+      });
+    } catch (err) {
+      fatal(
+        `Could not parse "${args.file}" — expected a valid .fit file: ${(err as Error).message}`,
+      );
+    }
+
+    // ---- Format output
+    const formatted = formatResult(result, format, outputProfile);
+
+    // ---- Print warnings
+    for (const warning of formatted.warnings) {
+      console.error(`Warning: ${warning}`);
+    }
+
+    // ---- Output
+    if (args.output) {
+      await writeFile(args.output, formatted.output);
+      console.error(`Written to ${args.output}`);
+    } else {
+      process.stdout.write(formatted.output);
+    }
   },
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { ENGINE_VERSION } from "@run2max/engine";
 const main = defineCommand({
   meta: {
     name: "run2max",
-    version: "0.0.1",
+    version: "1.0.0",
     description: "Structured run analysis from .fit files",
   },
   subCommands: {

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -149,3 +149,11 @@ pnpm --filter @run2max/engine exec vitest run
 # With smoke tests against a real .fit file
 FIT_FIXTURE=./fixture-fits/your-run.fit pnpm --filter @run2max/engine exec vitest run
 ```
+
+### Known gap: Tier 1-only smoke test
+
+The smoke tests assume a Stryd `.fit` file (Tier 2 + Tier 3 data present).
+A smoke test that exercises the full pipeline with a Tier 1-only file (no
+running dynamics, no Stryd fields) is pending — waiting on a `.fit` file from
+a non-Stryd device. Until then, tier degradation is covered at the unit level
+by `detect-capabilities.test.ts`.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@run2max/engine",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -3,6 +3,6 @@ import { ENGINE_VERSION } from "./index.js";
 
 describe("engine", () => {
   it("exports a version string", () => {
-    expect(ENGINE_VERSION).toBe("0.0.1");
+    expect(ENGINE_VERSION).toBe("1.0.0");
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,4 @@
-export const ENGINE_VERSION = "0.0.1";
+export const ENGINE_VERSION = "1.0.0";
 
 // ---------------------------------------------------------------------------
 // Public types


### PR DESCRIPTION
Ships CLI (run2max quantify) 

  - CLI (packages/cli) — `quantify` command with all planned flags: -`-workout`, `--block`, `--rpe`,
  `--notes`, `--format`, `--profile`, `--output`, `--timezone`, `--downsample`, `--config`, `--exclude-anomalies`.
  Full input validation and user-friendly error messages throughout.
  - Releases v1.0.0
