### PR TITLE
Adds plan schema, types, and validation. Resolves #8

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -62,3 +62,12 @@ export type {
   ColumnId,
   AnalysisMetadata,
 } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Plan schema, types, and validation
+// ---------------------------------------------------------------------------
+
+export { parsePlan, PLANNED_WEEK_TYPES, EXECUTED_ONLY_TYPES, ALL_WEEK_TYPES, REASON_CATEGORIES, KNOWN_DISTANCES } from "./plan/schema.js";
+export type { Plan, Mesocycle, Fractal, Week, TestingPeriod } from "./plan/schema.js";
+export { validatePlan } from "./plan/validate.js";
+export type { Diagnostic } from "./plan/validate.js";

--- a/packages/engine/src/plan/schema.test.ts
+++ b/packages/engine/src/plan/schema.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePlan,
+  PLANNED_WEEK_TYPES,
+  EXECUTED_ONLY_TYPES,
+  ALL_WEEK_TYPES,
+  REASON_CATEGORIES,
+  KNOWN_DISTANCES,
+} from "./schema.js";
+
+const minimalPlan = {
+  schema_version: 1,
+  block: "build",
+  start: "2026-05-04",
+  mesocycles: [
+    {
+      name: "CANAL",
+      fractals: [
+        {
+          weeks: [{ planned: "L", start: "2026-05-04" }],
+        },
+      ],
+    },
+  ],
+};
+
+const fullPlan = {
+  schema_version: 1,
+  block: "build",
+  goal: "Half Marathon Santiago",
+  distance: "half-marathon",
+  race_date: "2026-10-18",
+  start: "2026-05-04",
+  mesocycles: [
+    {
+      name: "CANAL",
+      fractals: [
+        {
+          weeks: [
+            { planned: "L", start: "2026-05-04", executed: "L" },
+            {
+              planned: "LLL",
+              start: "2026-05-11",
+              executed: "INC",
+              reason: "illness",
+              note: "stomach flu",
+            },
+            {
+              planned: "Ta",
+              start: "2026-05-18",
+              executed: "Ta",
+              testing_period: {
+                cp: 302,
+                e_ftp: 298,
+                lthr: 173,
+                zones: {
+                  E: { min: 0, max: 214 },
+                  M: { min: 215, max: 255 },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("parsePlan", () => {
+  it("accepts a minimal plan with one mesocycle and one week", () => {
+    const result = parsePlan(minimalPlan);
+    expect(result.block).toBe("build");
+    expect(result.start).toBe("2026-05-04");
+    expect(result.mesocycles).toHaveLength(1);
+    expect(result.mesocycles[0]!.fractals[0]!.weeks).toHaveLength(1);
+  });
+
+  it("accepts a full plan with all optional fields", () => {
+    const result = parsePlan(fullPlan);
+    expect(result.goal).toBe("Half Marathon Santiago");
+    expect(result.distance).toBe("half-marathon");
+    expect(result.raceDate).toBe("2026-10-18");
+    const week = result.mesocycles[0]!.fractals[0]!.weeks[2]!;
+    expect(week.testingPeriod?.cp).toBe(302);
+    expect(week.testingPeriod?.lthr).toBe(173);
+    expect(week.note).toBeUndefined();
+  });
+
+  it("transforms snake_case keys to camelCase", () => {
+    const result = parsePlan(fullPlan);
+    expect(result.raceDate).toBe("2026-10-18");
+    const week = result.mesocycles[0]!.fractals[0]!.weeks[2]!;
+    expect(week.testingPeriod).toBeDefined();
+    expect(week.testingPeriod?.eFtp).toBe(298);
+  });
+
+  it("throws when schemaVersion is missing", () => {
+    const { schema_version: _, ...withoutVersion } = minimalPlan;
+    expect(() => parsePlan(withoutVersion)).toThrow();
+  });
+
+  it("throws when schemaVersion is not 1", () => {
+    expect(() => parsePlan({ ...minimalPlan, schema_version: 2 })).toThrow();
+  });
+
+  it("throws when block name is missing", () => {
+    const { block: _, ...withoutBlock } = minimalPlan;
+    expect(() => parsePlan(withoutBlock)).toThrow();
+  });
+
+  it("throws when start date is missing", () => {
+    const { start: _, ...withoutStart } = minimalPlan;
+    expect(() => parsePlan(withoutStart)).toThrow();
+  });
+
+  it("throws when mesocycles is empty", () => {
+    expect(() => parsePlan({ ...minimalPlan, mesocycles: [] })).toThrow();
+  });
+
+  it("throws when a fractal has no weeks", () => {
+    expect(() =>
+      parsePlan({
+        ...minimalPlan,
+        mesocycles: [{ name: "CANAL", fractals: [{ weeks: [] }] }],
+      })
+    ).toThrow();
+  });
+
+  it("throws when a week is missing planned", () => {
+    expect(() =>
+      parsePlan({
+        ...minimalPlan,
+        mesocycles: [{ name: "CANAL", fractals: [{ weeks: [{ start: "2026-05-04" }] }] }],
+      })
+    ).toThrow();
+  });
+
+  it("throws when a week is missing start", () => {
+    expect(() =>
+      parsePlan({
+        ...minimalPlan,
+        mesocycles: [{ name: "CANAL", fractals: [{ weeks: [{ planned: "L" }] }] }],
+      })
+    ).toThrow();
+  });
+
+  it("accepts weeks with executed matching planned", () => {
+    const result = parsePlan({
+      ...minimalPlan,
+      mesocycles: [
+        { name: "CANAL", fractals: [{ weeks: [{ planned: "L", start: "2026-05-04", executed: "L" }] }] },
+      ],
+    });
+    expect(result.mesocycles[0]!.fractals[0]!.weeks[0]!.executed).toBe("L");
+  });
+
+  it("accepts weeks with INC/DNF as executed", () => {
+    const result = parsePlan({
+      ...minimalPlan,
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            {
+              weeks: [
+                { planned: "L", start: "2026-05-04", executed: "INC", reason: "illness" },
+                { planned: "LL", start: "2026-05-11", executed: "DNF", reason: "injury" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.mesocycles[0]!.fractals[0]!.weeks[0]!.executed).toBe("INC");
+    expect(result.mesocycles[0]!.fractals[0]!.weeks[1]!.executed).toBe("DNF");
+  });
+
+  it("accepts testingPeriod with partial fields", () => {
+    const result = parsePlan({
+      ...minimalPlan,
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            { weeks: [{ planned: "Ta", start: "2026-05-04", testing_period: { cp: 302 } }] },
+          ],
+        },
+      ],
+    });
+    expect(result.mesocycles[0]!.fractals[0]!.weeks[0]!.testingPeriod?.cp).toBe(302);
+    expect(result.mesocycles[0]!.fractals[0]!.weeks[0]!.testingPeriod?.lthr).toBeUndefined();
+  });
+
+  it("accepts testingPeriod zones as open record", () => {
+    const result = parsePlan({
+      ...minimalPlan,
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            {
+              weeks: [
+                {
+                  planned: "Ta",
+                  start: "2026-05-04",
+                  testing_period: {
+                    zones: {
+                      SPRINT: { min: 400, max: 999 },
+                      CUSTOM: { min: 0, max: 100 },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const zones = result.mesocycles[0]!.fractals[0]!.weeks[0]!.testingPeriod?.zones;
+    expect(zones?.SPRINT).toEqual({ min: 400, max: 999 });
+    expect(zones?.CUSTOM).toEqual({ min: 0, max: 100 });
+  });
+
+  it("accepts unknown distance strings", () => {
+    const result = parsePlan({ ...minimalPlan, distance: "ultramarathon" });
+    expect(result.distance).toBe("ultramarathon");
+  });
+
+  it("exports const arrays with correct values", () => {
+    expect(PLANNED_WEEK_TYPES).toContain("L");
+    expect(PLANNED_WEEK_TYPES).toContain("Ta");
+    expect(PLANNED_WEEK_TYPES).not.toContain("INC");
+    expect(EXECUTED_ONLY_TYPES).toContain("INC");
+    expect(EXECUTED_ONLY_TYPES).toContain("DNF");
+    expect(ALL_WEEK_TYPES).toContain("L");
+    expect(ALL_WEEK_TYPES).toContain("INC");
+    expect(REASON_CATEGORIES).toContain("illness");
+    expect(KNOWN_DISTANCES).toContain("marathon");
+  });
+});

--- a/packages/engine/src/plan/schema.ts
+++ b/packages/engine/src/plan/schema.ts
@@ -1,0 +1,78 @@
+import * as v from "valibot";
+
+function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function transformKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(transformKeys);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        snakeToCamel(k),
+        transformKeys(v),
+      ])
+    );
+  }
+  return value;
+}
+
+export const PLANNED_WEEK_TYPES = ["L", "LL", "LLL", "D", "Ta", "Tb", "P", "R", "N"] as const;
+export const EXECUTED_ONLY_TYPES = ["INC", "DNF"] as const;
+export const ALL_WEEK_TYPES = [...PLANNED_WEEK_TYPES, ...EXECUTED_ONLY_TYPES] as const;
+export const REASON_CATEGORIES = ["illness", "injury", "travel", "personal", "weather", "schedule"] as const;
+export const KNOWN_DISTANCES = ["5k", "10k", "half-marathon", "marathon"] as const;
+
+const TestingPeriodSchema = v.object({
+  cp: v.optional(v.number()),
+  eFtp: v.optional(v.number()),
+  lthr: v.optional(v.number()),
+  zones: v.optional(v.record(v.string(), v.object({ min: v.number(), max: v.number() }))),
+});
+
+const WeekSchema = v.object({
+  planned: v.string(),
+  start: v.string(),
+  executed: v.optional(v.string()),
+  reason: v.optional(v.string()),
+  note: v.optional(v.string()),
+  testingPeriod: v.optional(TestingPeriodSchema),
+});
+
+const FractalSchema = v.object({
+  weeks: v.pipe(
+    v.array(WeekSchema),
+    v.minLength(1, "weeks must contain at least one entry")
+  ),
+});
+
+const MesocycleSchema = v.object({
+  name: v.string(),
+  fractals: v.pipe(
+    v.array(FractalSchema),
+    v.minLength(1, "fractals must contain at least one entry")
+  ),
+});
+
+export const PlanSchema = v.object({
+  schemaVersion: v.literal(1),
+  block: v.string(),
+  goal: v.optional(v.string()),
+  distance: v.optional(v.string()),
+  raceDate: v.optional(v.string()),
+  start: v.string(),
+  mesocycles: v.pipe(
+    v.array(MesocycleSchema),
+    v.minLength(1, "mesocycles must contain at least one entry")
+  ),
+});
+
+export type Plan = v.InferOutput<typeof PlanSchema>;
+export type Mesocycle = v.InferOutput<typeof MesocycleSchema>;
+export type Fractal = v.InferOutput<typeof FractalSchema>;
+export type Week = v.InferOutput<typeof WeekSchema>;
+export type TestingPeriod = v.InferOutput<typeof TestingPeriodSchema>;
+
+export function parsePlan(raw: unknown): Plan {
+  return v.parse(PlanSchema, transformKeys(raw));
+}

--- a/packages/engine/src/plan/validate.test.ts
+++ b/packages/engine/src/plan/validate.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parsePlan } from "./schema.js";
+import { validatePlan } from "./validate.js";
+
+function makePlan(weeks: object[]) {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    start: "2026-05-04",
+    mesocycles: [{ name: "CANAL", fractals: [{ weeks }] }],
+  });
+}
+
+describe("validatePlan", () => {
+  it("returns no errors for a valid plan", () => {
+    const plan = makePlan([
+      { planned: "L", start: "2026-05-04", executed: "L" },
+      { planned: "LL", start: "2026-05-11", executed: "LL" },
+    ]);
+    expect(validatePlan(plan)).toHaveLength(0);
+  });
+
+  it("returns error when reason is set on non-INC/DNF week", () => {
+    const plan = makePlan([
+      { planned: "L", start: "2026-05-04", executed: "L", reason: "illness" },
+    ]);
+    const errors = validatePlan(plan);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]!.code).toBe("REASON_WITHOUT_DEVIATION");
+  });
+
+  it("returns error when INC or DNF is used as planned type", () => {
+    const plan = makePlan([{ planned: "INC", start: "2026-05-04" }]);
+    const errors = validatePlan(plan);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]!.code).toBe("EXECUTED_ONLY_AS_PLANNED");
+  });
+
+  it("returns error when testingPeriod is on a non-test week", () => {
+    const plan = makePlan([
+      { planned: "L", start: "2026-05-04", testing_period: { lthr: 173 } },
+    ]);
+    const errors = validatePlan(plan);
+    expect(errors.some(e => e.code === "TESTING_PERIOD_ON_NON_TEST_WEEK")).toBe(true);
+  });
+
+  it("allows testingPeriod on INC test week", () => {
+    const plan = makePlan([
+      { planned: "Ta", start: "2026-05-04", executed: "INC", testing_period: { lthr: 173 } },
+    ]);
+    expect(validatePlan(plan)).toHaveLength(0);
+  });
+
+  it("returns error when testingPeriod is on DNF test week", () => {
+    const plan = makePlan([
+      { planned: "Ta", start: "2026-05-04", executed: "DNF", testing_period: { lthr: 173 } },
+    ]);
+    const errors = validatePlan(plan);
+    expect(errors.some(e => e.code === "TESTING_PERIOD_ON_DNF_WEEK")).toBe(true);
+  });
+
+  it("returns error when CP is recorded but Ta was DNF", () => {
+    const plan = makePlan([
+      { planned: "Ta", start: "2026-05-04", executed: "DNF" },
+      { planned: "Tb", start: "2026-05-11", executed: "Tb", testing_period: { cp: 302 } },
+    ]);
+    const errors = validatePlan(plan);
+    expect(errors.some(e => e.code === "CP_WITHOUT_TA_EXECUTION")).toBe(true);
+  });
+
+  it("returns error when CP is recorded but Ta was INC without testingPeriod", () => {
+    const plan = makePlan([
+      { planned: "Ta", start: "2026-05-04", executed: "INC" },
+      { planned: "Tb", start: "2026-05-11", executed: "Tb", testing_period: { cp: 302 } },
+    ]);
+    const errors = validatePlan(plan);
+    expect(errors.some(e => e.code === "CP_WITHOUT_TA_TEST_PERIOD")).toBe(true);
+  });
+
+  it("returns multiple errors at once", () => {
+    const plan = makePlan([
+      { planned: "INC", start: "2026-05-04", reason: "illness" },
+      { planned: "DNF", start: "2026-05-11" },
+    ]);
+    const errors = validatePlan(plan);
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/engine/src/plan/validate.ts
+++ b/packages/engine/src/plan/validate.ts
@@ -1,0 +1,90 @@
+import type { Plan, Week } from "./schema.js";
+import { EXECUTED_ONLY_TYPES } from "./schema.js";
+
+export interface Diagnostic {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+const EXECUTED_ONLY_SET = new Set<string>(EXECUTED_ONLY_TYPES);
+const TEST_WEEK_TYPES = new Set(["Ta", "Tb"]);
+
+export function validatePlan(plan: Plan): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+
+  plan.mesocycles.forEach((meso, mi) => {
+    meso.fractals.forEach((fractal, fi) => {
+      const weeks = fractal.weeks;
+
+      weeks.forEach((week, wi) => {
+        const path = `mesocycles[${mi}].fractals[${fi}].weeks[${wi}]`;
+
+        if (EXECUTED_ONLY_SET.has(week.planned)) {
+          diagnostics.push({
+            code: "EXECUTED_ONLY_AS_PLANNED",
+            message: `"${week.planned}" is an executed-only type and cannot be used as planned`,
+            path: `${path}.planned`,
+          });
+        }
+
+        if (week.reason !== undefined && week.executed !== "INC" && week.executed !== "DNF") {
+          diagnostics.push({
+            code: "REASON_WITHOUT_DEVIATION",
+            message: `reason is only valid when executed is INC or DNF`,
+            path: `${path}.reason`,
+          });
+        }
+
+        if (week.testingPeriod !== undefined) {
+          const isTestWeek = TEST_WEEK_TYPES.has(week.planned);
+
+          if (!isTestWeek) {
+            diagnostics.push({
+              code: "TESTING_PERIOD_ON_NON_TEST_WEEK",
+              message: `testingPeriod is only valid on Ta or Tb weeks`,
+              path: `${path}.testingPeriod`,
+            });
+          } else if (week.executed === "DNF") {
+            diagnostics.push({
+              code: "TESTING_PERIOD_ON_DNF_WEEK",
+              message: `testingPeriod is not valid on a DNF week`,
+              path: `${path}.testingPeriod`,
+            });
+          }
+        }
+      });
+
+      weeks.forEach((week, wi) => {
+        if (week.testingPeriod?.cp === undefined) return;
+
+        const path = `mesocycles[${mi}].fractals[${fi}].weeks[${wi}].testingPeriod.cp`;
+        const ta = findPrecedingTa(weeks, wi);
+        if (ta === undefined) return;
+
+        if (ta.executed === "DNF") {
+          diagnostics.push({
+            code: "CP_WITHOUT_TA_EXECUTION",
+            message: `CP cannot be recorded when Ta was DNF`,
+            path,
+          });
+        } else if (ta.executed === "INC" && ta.testingPeriod === undefined) {
+          diagnostics.push({
+            code: "CP_WITHOUT_TA_TEST_PERIOD",
+            message: `CP cannot be recorded when Ta was INC without testingPeriod`,
+            path,
+          });
+        }
+      });
+    });
+  });
+
+  return diagnostics;
+}
+
+function findPrecedingTa(weeks: readonly Week[], currentIndex: number): Week | undefined {
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    if (weeks[i]!.planned === "Ta") return weeks[i];
+  }
+  return undefined;
+}


### PR DESCRIPTION
Define the valibot schema for plan.yaml, the TypeScript types inferred from it, and a semantic validation pass that enforces cross-field rules. This is the foundation all plan commands build on.