### PR TITLE
Adds `plan validate` CLI command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
 # @run2max/cli
 
-CLI for run2max. Parses a `.fit` file and produces a structured run analysis as
-markdown, JSON, or YAML.
+CLI for run2max. Parses `.fit` files into structured run analysis and manages
+training plan files.
 
 ## Installation
 
@@ -77,6 +77,23 @@ run2max quantify my-run.fit --config ./run2max.config.yaml
 | `--config`            | `-c`  | —       | Explicit config file path |
 | `--exclude-anomalies` | —     | `false` | Exclude anomalous values from aggregations |
 | `--no-weather`        | —     | `false` | Skip weather fetch for this run |
+
+## Plan commands
+
+```bash
+run2max plan validate [plan.yaml]
+```
+
+Validates a `plan.yaml` file — structure (schema) and semantics (e.g. no
+executed-only types in the `planned` field, no `testingPeriod` on DNF weeks).
+
+Defaults to `./plan.yaml` in the current directory. Pass a path to validate a
+specific file.
+
+**Output:** `error: <message> (<path>)` lines, then a summary (`2 errors`).
+Prints `plan.yaml is valid` on success.
+
+**Exit codes:** `0` on success, `1` on errors.
 
 ## Config
 

--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -1,0 +1,11 @@
+import { defineCommand } from "citty";
+
+export default defineCommand({
+  meta: {
+    name: "plan",
+    description: "Manage and inspect training plan",
+  },
+  subCommands: {
+    validate: () => import("./validate.js").then((m) => m.default),
+  },
+});

--- a/packages/cli/src/commands/plan/validate.ts
+++ b/packages/cli/src/commands/plan/validate.ts
@@ -1,0 +1,47 @@
+import { defineCommand } from "citty";
+import { join } from "node:path";
+import { loadPlan, validatePlan } from "@run2max/engine";
+import type { Diagnostic } from "@run2max/engine";
+
+export default defineCommand({
+  meta: {
+    name: "validate",
+    description: "Validate plan.yaml structure and semantics",
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "Path to plan.yaml (defaults to ./plan.yaml)",
+      required: false,
+    },
+  },
+
+  async run({ args }) {
+    const filePath = args.file ?? join(process.cwd(), "plan.yaml");
+
+    let plan;
+    try {
+      plan = await loadPlan(filePath);
+    } catch (err) {
+      console.error(`error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const diagnostics: Diagnostic[] = validatePlan(plan);
+
+    for (const d of diagnostics) {
+      const loc = d.path ? ` (${d.path})` : "";
+      console.error(`error: ${d.message}${loc}`);
+    }
+
+    const errorCount = diagnostics.length;
+
+    if (errorCount > 0) {
+      const noun = errorCount === 1 ? "error" : "errors";
+      console.error(`${errorCount} ${noun}`);
+      process.exit(1);
+    }
+
+    console.log("plan.yaml is valid");
+  },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ const main = defineCommand({
   },
   subCommands: {
     quantify: () => import("./commands/quantify.js").then((m) => m.default),
+    plan: () => import("./commands/plan/index.js").then((m) => m.default),
   },
 });
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -14,6 +14,10 @@ import {
   classifyZone,
   computeElevationProfile,
   computeNormalizedPower,
+  // plan
+  loadPlan,
+  parsePlan,
+  validatePlan,
 } from "@run2max/engine";
 import type {
   AnalysisResult,
@@ -28,6 +32,13 @@ import type {
   ElevationProfile,
   WeatherSummary,
   WeatherPerSplit,
+  // plan
+  Plan,
+  Mesocycle,
+  Fractal,
+  Week,
+  TestingPeriod,
+  Diagnostic,
 } from "@run2max/engine";
 ```
 
@@ -128,6 +139,35 @@ Warnings are returned (not thrown) for dropped columns or skipped sections.
 ```ts
 const { hasRunningDynamics, hasStrydEnhanced } = detectCapabilities(records);
 ```
+
+### `loadPlan(filePath)`
+
+Reads a `plan.yaml` from disk, transforms snake_case keys to camelCase, and
+parses it against the plan schema. Throws with a descriptive message on missing
+file, invalid YAML, or schema failure.
+
+```ts
+const plan = await loadPlan("./plan.yaml");
+```
+
+### `parsePlan(raw)`
+
+Parses a raw (already-deserialized) object against the plan schema. Called
+internally by `loadPlan`; use it when you already have the parsed YAML object.
+
+### `validatePlan(plan)`
+
+Runs semantic checks on a parsed `Plan` and returns `Diagnostic[]`. An empty
+array means the plan is semantically valid.
+
+```ts
+const diagnostics = validatePlan(plan);
+// [{ code: "EXECUTED_ONLY_AS_PLANNED", message: "...", path: "..." }]
+```
+
+Checks performed: executed-only types used as `planned`, `reason` without a
+deviation, `testingPeriod` on non-test or DNF weeks, CP recorded when Ta was
+DNF or INC without test results.
 
 ## Data tiers
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -71,3 +71,4 @@ export { parsePlan, PLANNED_WEEK_TYPES, EXECUTED_ONLY_TYPES, ALL_WEEK_TYPES, REA
 export type { Plan, Mesocycle, Fractal, Week, TestingPeriod } from "./plan/schema.js";
 export { validatePlan } from "./plan/validate.js";
 export type { Diagnostic } from "./plan/validate.js";
+export { loadPlan } from "./plan/loader.js";

--- a/packages/engine/src/plan/loader.test.ts
+++ b/packages/engine/src/plan/loader.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadPlan } from "./loader.js";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "run2max-loader-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const validPlanYaml = `
+schema_version: 1
+block: build
+start: 2026-05-04
+mesocycles:
+  - name: CANAL
+    fractals:
+      - weeks:
+          - planned: L
+            start: 2026-05-04
+`;
+
+describe("loadPlan", () => {
+  it("parses a valid plan.yaml file", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "plan.yaml");
+      await writeFile(filePath, validPlanYaml, "utf-8");
+
+      const plan = await loadPlan(filePath);
+
+      expect(plan.schemaVersion).toBe(1);
+      expect(plan.block).toBe("build");
+      expect(plan.start).toBe("2026-05-04");
+      expect(plan.mesocycles).toHaveLength(1);
+      expect(plan.mesocycles[0]!.name).toBe("CANAL");
+    });
+  });
+
+  it("throws when file not found", async () => {
+    await expect(loadPlan("/nonexistent/path/plan.yaml")).rejects.toThrow(
+      "File not found: /nonexistent/path/plan.yaml"
+    );
+  });
+
+  it("throws with descriptive error on invalid YAML", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "plan.yaml");
+      await writeFile(filePath, "block: {\n  bad yaml: [unclosed", "utf-8");
+
+      await expect(loadPlan(filePath)).rejects.toThrow(/Failed to parse/);
+    });
+  });
+
+  it("transforms snake_case keys to camelCase", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "plan.yaml");
+      const yaml = `
+schema_version: 1
+block: build
+race_date: 2026-10-18
+start: 2026-05-04
+mesocycles:
+  - name: CANAL
+    fractals:
+      - weeks:
+          - planned: Ta
+            start: 2026-05-04
+            testing_period:
+              cp: 302
+`;
+      await writeFile(filePath, yaml, "utf-8");
+
+      const plan = await loadPlan(filePath);
+
+      expect(plan.raceDate).toBe("2026-10-18");
+      expect(plan.mesocycles[0]!.fractals[0]!.weeks[0]!.testingPeriod?.cp).toBe(302);
+    });
+  });
+});

--- a/packages/engine/src/plan/loader.ts
+++ b/packages/engine/src/plan/loader.ts
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { parse as parseYaml } from "yaml";
+import { parsePlan, type Plan } from "./schema.js";
+import * as v from "valibot";
+
+export async function loadPlan(filePath: string): Promise<Plan> {
+  let contents: string;
+  try {
+    contents = await readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`File not found: ${filePath}`);
+    }
+    throw err;
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(contents);
+  } catch (err) {
+    throw new Error(`Failed to parse ${filePath}: ${(err as Error).message}`);
+  }
+
+  try {
+    return parsePlan(raw);
+  } catch (err) {
+    if (err instanceof v.ValiError) {
+      const issues = err.issues
+        .map((issue) => {
+          const path = issue.path?.map((p: { key: unknown }) => p.key).join(".") ?? "(root)";
+          return `  ${path}: ${issue.message}`;
+        })
+        .join("\n");
+      throw new Error(`Invalid plan at ${filePath}:\n${issues}`);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Exposes plan.yaml validation as a standalone CLI command. Thin wrapper around the engine's parsePlan() and validatePlan()