### PR TITLE
Adds built-in plan templates

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -72,3 +72,10 @@ export type { Plan, Mesocycle, Fractal, Week, TestingPeriod } from "./plan/schem
 export { validatePlan } from "./plan/validate.js";
 export type { Diagnostic } from "./plan/validate.js";
 export { loadPlan } from "./plan/loader.js";
+
+// ---------------------------------------------------------------------------
+// Plan templates
+// ---------------------------------------------------------------------------
+
+export type { PlanTemplate } from "./plan/templates/types.js";
+export { BUILTIN_TEMPLATES, getBuiltinTemplate } from "./plan/templates/builtin.js";

--- a/packages/engine/src/plan/templates/builtin.test.ts
+++ b/packages/engine/src/plan/templates/builtin.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { BUILTIN_TEMPLATES, getBuiltinTemplate } from "./builtin.js";
+import { PLANNED_WEEK_TYPES } from "../schema.js";
+import type { PlanTemplate } from "./types.js";
+
+function countWeeks(template: PlanTemplate): number {
+  return template.mesocycles.reduce(
+    (sum, meso) =>
+      sum + meso.fractals.reduce((fsum, fractal) => fsum + fractal.length, 0),
+    0
+  );
+}
+
+function allWeeks(template: PlanTemplate): string[] {
+  return template.mesocycles.flatMap((meso) => meso.fractals.flat());
+}
+
+describe("BUILTIN_TEMPLATES", () => {
+  it("exports 5 built-in templates", () => {
+    expect(BUILTIN_TEMPLATES).toHaveLength(5);
+  });
+
+  it("each template has a unique name", () => {
+    const names = BUILTIN_TEMPLATES.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("each template has at least one mesocycle", () => {
+    for (const template of BUILTIN_TEMPLATES) {
+      expect(template.mesocycles.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each mesocycle has at least one fractal with at least one week", () => {
+    for (const template of BUILTIN_TEMPLATES) {
+      for (const meso of template.mesocycles) {
+        expect(meso.fractals.length).toBeGreaterThan(0);
+        for (const fractal of meso.fractals) {
+          expect(fractal.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("all week types in templates are valid planned types", () => {
+    const valid = new Set(PLANNED_WEEK_TYPES);
+    for (const template of BUILTIN_TEMPLATES) {
+      for (const week of allWeeks(template)) {
+        expect(valid.has(week as (typeof PLANNED_WEEK_TYPES)[number])).toBe(true);
+      }
+    }
+  });
+});
+
+describe("getBuiltinTemplate", () => {
+  it("returns template by name", () => {
+    const t = getBuiltinTemplate("1-meso");
+    expect(t).toBeDefined();
+    expect(t?.name).toBe("1-meso");
+  });
+
+  it("returns undefined for unknown name", () => {
+    expect(getBuiltinTemplate("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("1-meso template", () => {
+  it("has 6 weeks", () => {
+    const t = getBuiltinTemplate("1-meso")!;
+    expect(countWeeks(t)).toBe(6);
+  });
+});
+
+describe("2-meso-race template", () => {
+  it("has 16 weeks", () => {
+    const t = getBuiltinTemplate("2-meso-race")!;
+    expect(countWeeks(t)).toBe(16);
+  });
+});
+
+describe("bridge template", () => {
+  it("has no test or race weeks", () => {
+    const t = getBuiltinTemplate("bridge")!;
+    const forbidden = new Set(["Ta", "Tb", "P", "R", "N"]);
+    for (const week of allWeeks(t)) {
+      expect(forbidden.has(week)).toBe(false);
+    }
+  });
+});

--- a/packages/engine/src/plan/templates/builtin.ts
+++ b/packages/engine/src/plan/templates/builtin.ts
@@ -1,0 +1,62 @@
+import type { PlanTemplate } from "./types.js";
+
+const MESO_FRACTAL = ["L", "LL", "LLL", "D", "Ta", "Tb"];
+const TAPER_FRACTAL = ["P", "P", "R", "N"];
+
+const ONE_MESO: PlanTemplate = {
+  name: "1-meso",
+  description: "Single mesocycle with one load-test fractal (6 weeks).",
+  mesocycles: [
+    { name: "MESO-1", fractals: [MESO_FRACTAL] },
+  ],
+};
+
+const TWO_MESO: PlanTemplate = {
+  name: "2-meso",
+  description: "Two mesocycles, each with one load-test fractal (12 weeks).",
+  mesocycles: [
+    { name: "MESO-1", fractals: [MESO_FRACTAL] },
+    { name: "MESO-2", fractals: [MESO_FRACTAL] },
+  ],
+};
+
+const TWO_MESO_RACE: PlanTemplate = {
+  name: "2-meso-race",
+  description: "Two build mesocycles plus taper/race/transition (16 weeks). Half-marathon default.",
+  mesocycles: [
+    { name: "MESO-1", fractals: [MESO_FRACTAL] },
+    { name: "MESO-2", fractals: [MESO_FRACTAL] },
+    { name: "TAPER", fractals: [TAPER_FRACTAL] },
+  ],
+};
+
+const THREE_MESO_RACE: PlanTemplate = {
+  name: "3-meso-race",
+  description: "Three build mesocycles plus taper/race/transition (22 weeks). Marathon default.",
+  mesocycles: [
+    { name: "MESO-1", fractals: [MESO_FRACTAL] },
+    { name: "MESO-2", fractals: [MESO_FRACTAL] },
+    { name: "MESO-3", fractals: [MESO_FRACTAL] },
+    { name: "TAPER", fractals: [TAPER_FRACTAL] },
+  ],
+};
+
+const BRIDGE: PlanTemplate = {
+  name: "bridge",
+  description: "Short bridge block with a single load fractal, no test or race weeks (4 weeks).",
+  mesocycles: [
+    { name: "MESO-1", fractals: [["L", "LL", "LLL", "D"]] },
+  ],
+};
+
+export const BUILTIN_TEMPLATES: PlanTemplate[] = [
+  ONE_MESO,
+  TWO_MESO,
+  TWO_MESO_RACE,
+  THREE_MESO_RACE,
+  BRIDGE,
+];
+
+export function getBuiltinTemplate(name: string): PlanTemplate | undefined {
+  return BUILTIN_TEMPLATES.find((t) => t.name === name);
+}

--- a/packages/engine/src/plan/templates/types.ts
+++ b/packages/engine/src/plan/templates/types.ts
@@ -1,0 +1,8 @@
+export interface PlanTemplate {
+  name: string;
+  description: string;
+  mesocycles: {
+    name: string;
+    fractals: string[][];
+  }[];
+}


### PR DESCRIPTION
Define the template data structure and ship the 5 built-in templates that plan create uses to scaffold a plan.yaml. Pure data — no file I/O or user template loading.

Resolves #11 