### PR TITLE
Adds plan create — simple path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,9 +14,11 @@
   },
   "dependencies": {
     "@run2max/engine": "workspace:*",
-    "citty": "^0.1.6"
+    "citty": "^0.1.6",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.0"
   }

--- a/packages/cli/src/commands/plan/create.ts
+++ b/packages/cli/src/commands/plan/create.ts
@@ -1,0 +1,150 @@
+import { defineCommand } from "citty";
+import { join } from "node:path";
+import { writeFile, access } from "node:fs/promises";
+import { stringify as stringifyYaml } from "yaml";
+import {
+  buildPlanFromTemplate,
+  loadUserTemplates,
+  resolveTemplate,
+  BUILTIN_TEMPLATES,
+  validatePlan,
+  type Plan,
+} from "@run2max/engine";
+
+function camelToSnake(str: string): string {
+  return str.replace(/([A-Z])/g, (_, c: string) => `_${c.toLowerCase()}`);
+}
+
+function transformKeysToSnake(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(transformKeysToSnake);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        camelToSnake(k),
+        transformKeysToSnake(v),
+      ])
+    );
+  }
+  return value;
+}
+
+export default defineCommand({
+  meta: {
+    name: "create",
+    description: "Create a new plan.yaml from a template",
+  },
+  args: {
+    template: {
+      type: "string",
+      description: "Template name (built-in or user-defined)",
+      required: true,
+    },
+    block: {
+      type: "string",
+      description: "Training block name",
+      required: true,
+    },
+    start: {
+      type: "string",
+      description: "Start date (YYYY-MM-DD, must fall on configured week_start day)",
+      required: true,
+    },
+    goal: {
+      type: "string",
+      description: "Race or goal description",
+      required: false,
+    },
+    distance: {
+      type: "string",
+      description: "Race distance (5k, 10k, half-marathon, marathon)",
+      required: false,
+    },
+    raceDate: {
+      type: "string",
+      description: "Race date (YYYY-MM-DD)",
+      required: false,
+    },
+    dir: {
+      type: "string",
+      description: "Output directory (defaults to current directory)",
+      required: false,
+    },
+    force: {
+      type: "boolean",
+      description: "Overwrite existing plan.yaml",
+      default: false,
+    },
+  },
+
+  async run({ args }) {
+    const userTemplatesDir = join(
+      process.env["HOME"] ?? process.env["USERPROFILE"] ?? ".",
+      ".config",
+      "run2max",
+      "templates"
+    );
+    const userTemplates = await loadUserTemplates(userTemplatesDir);
+    const resolved = resolveTemplate(args.template, userTemplates);
+
+    if (!resolved) {
+      const available = [
+        ...userTemplates.map((t) => t.name),
+        ...BUILTIN_TEMPLATES.map((t) => t.name),
+      ].join(", ");
+      console.error(`error: unknown template "${args.template}". Available: ${available}`);
+      process.exit(1);
+      return;
+    }
+
+    let plan: Plan;
+    try {
+      plan = buildPlanFromTemplate(resolved, {
+        block: args.block,
+        start: args.start,
+        goal: args.goal,
+        distance: args.distance,
+        raceDate: args.raceDate,
+      });
+    } catch (err) {
+      console.error(`error: ${(err as Error).message}`);
+      process.exit(1);
+      return;
+    }
+
+    const diagnostics = validatePlan(plan);
+    if (diagnostics.length > 0) {
+      for (const d of diagnostics) {
+        const loc = d.path ? ` (${d.path})` : "";
+        console.error(`error: ${d.message}${loc}`);
+      }
+      process.exit(1);
+      return;
+    }
+
+    const outDir = args.dir ?? process.cwd();
+    const filePath = join(outDir, "plan.yaml");
+
+    if (!args.force) {
+      try {
+        await access(filePath);
+        console.error(`error: ${filePath} already exists. Use --force to overwrite.`);
+        process.exit(1);
+        return;
+      } catch {
+        // file does not exist, proceed
+      }
+    }
+
+    const snakePlan = transformKeysToSnake(plan);
+    const yaml = stringifyYaml(snakePlan);
+    await writeFile(filePath, yaml, "utf-8");
+
+    const totalWeeks = plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks)).length;
+    const lastWeek = plan.mesocycles.at(-1)!.fractals.at(-1)!.weeks.at(-1)!;
+    const goalLine = plan.goal ? ` — ${plan.goal}` : "";
+    process.stderr.write(`created: ${filePath}\n`);
+    process.stderr.write(`  block: ${plan.block}${goalLine}\n`);
+    process.stderr.write(`  template: ${resolved.name}\n`);
+    process.stderr.write(`  weeks: ${totalWeeks} (${plan.start} → ${lastWeek.start})\n`);
+  },
+});

--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -6,6 +6,7 @@ export default defineCommand({
     description: "Manage and inspect training plan",
   },
   subCommands: {
+    create: () => import("./create.js").then((m) => m.default),
     validate: () => import("./validate.js").then((m) => m.default),
   },
 });

--- a/packages/engine/src/computations/quantify.test.ts
+++ b/packages/engine/src/computations/quantify.test.ts
@@ -64,6 +64,7 @@ function buildNormalizedData(recordCount: number) {
 }
 
 const CONFIG: Run2MaxConfig = {
+  schemaVersion: 1,
   powerZones: [
     { label: "E", name: "Easy", min: 204, max: 233 },
     { label: "M", name: "Marathon", min: 251, max: 260 },

--- a/packages/engine/src/computations/summary.test.ts
+++ b/packages/engine/src/computations/summary.test.ts
@@ -27,6 +27,7 @@ const METADATA: WorkoutMetadata = {
 };
 
 const CONFIG: Run2MaxConfig = {
+  schemaVersion: 1,
   powerZones: [
     { label: "E", name: "Easy", min: 204, max: 233 },
     { label: "M", name: "Marathon", min: 251, max: 260 },
@@ -100,6 +101,7 @@ describe("computeSummary", () => {
 
   it("falls back to calibration.lthr when thresholds.lthr missing", () => {
     const configWithCalib: Run2MaxConfig = {
+      schemaVersion: 1,
       powerZones: CONFIG.powerZones,
       calibration: { lthr: 168 },
     };
@@ -110,7 +112,7 @@ describe("computeSummary", () => {
   });
 
   it("sets avgHeartRatePctLthr to null when no lthr configured", () => {
-    const configNoLthr: Run2MaxConfig = { powerZones: CONFIG.powerZones };
+    const configNoLthr: Run2MaxConfig = { schemaVersion: 1, powerZones: CONFIG.powerZones };
     const records = [rec({ heartRate: 140 })];
     const result = computeSummary(records, SESSION, METADATA, configNoLthr, OPTIONS);
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -71,7 +71,9 @@ export { parsePlan, PLANNED_WEEK_TYPES, EXECUTED_ONLY_TYPES, ALL_WEEK_TYPES, REA
 export type { Plan, Mesocycle, Fractal, Week, TestingPeriod } from "./plan/schema.js";
 export { validatePlan } from "./plan/validate.js";
 export type { Diagnostic } from "./plan/validate.js";
-export { loadPlan } from "./plan/loader.js";
+export { loadPlan, loadUserTemplates, resolveTemplate } from "./plan/loader.js";
+export { buildPlanFromTemplate } from "./plan/build.js";
+export type { BuildPlanOptions } from "./plan/build.js";
 
 // ---------------------------------------------------------------------------
 // Plan templates

--- a/packages/engine/src/plan/build.test.ts
+++ b/packages/engine/src/plan/build.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { buildPlanFromTemplate } from "./build.js";
+import { getBuiltinTemplate } from "./templates/builtin.js";
+import { parsePlan } from "./schema.js";
+import { validatePlan } from "./validate.js";
+
+const MONDAY = "2026-05-04";
+
+describe("buildPlanFromTemplate", () => {
+  it("builds a plan from a 1-meso template with correct week count", () => {
+    const template = getBuiltinTemplate("1-meso")!;
+    const plan = buildPlanFromTemplate(template, { block: "build", start: MONDAY });
+    const weeks = plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks));
+    expect(weeks).toHaveLength(6);
+  });
+
+  it("assigns sequential 7-day start dates from --start", () => {
+    const template = getBuiltinTemplate("1-meso")!;
+    const plan = buildPlanFromTemplate(template, { block: "build", start: MONDAY });
+    const weeks = plan.mesocycles[0]!.fractals[0]!.weeks;
+    expect(weeks[0]!.start).toBe("2026-05-04");
+    expect(weeks[1]!.start).toBe("2026-05-11");
+    expect(weeks[2]!.start).toBe("2026-05-18");
+    expect(weeks[5]!.start).toBe("2026-06-08");
+  });
+
+  it("throws when start date does not fall on weekStart day", () => {
+    const template = getBuiltinTemplate("1-meso")!;
+    expect(() =>
+      buildPlanFromTemplate(template, { block: "build", start: "2026-05-05" })
+    ).toThrow(/does not fall on monday/);
+  });
+
+  it("uses monday as default weekStart", () => {
+    const template = getBuiltinTemplate("1-meso")!;
+    expect(() =>
+      buildPlanFromTemplate(template, { block: "build", start: MONDAY })
+    ).not.toThrow();
+    expect(() =>
+      buildPlanFromTemplate(template, { block: "build", start: "2026-05-05" })
+    ).toThrow();
+  });
+
+  it("includes block, goal, distance, raceDate when provided", () => {
+    const template = getBuiltinTemplate("2-meso-race")!;
+    const plan = buildPlanFromTemplate(template, {
+      block: "build",
+      start: MONDAY,
+      goal: "Half Marathon Santiago",
+      distance: "half-marathon",
+      raceDate: "2026-08-17",
+    });
+    expect(plan.block).toBe("build");
+    expect(plan.goal).toBe("Half Marathon Santiago");
+    expect(plan.distance).toBe("half-marathon");
+    expect(plan.raceDate).toBe("2026-08-17");
+  });
+
+  it("omits goal, distance, raceDate when not provided", () => {
+    const template = getBuiltinTemplate("bridge")!;
+    const plan = buildPlanFromTemplate(template, { block: "bridge-block", start: MONDAY });
+    expect(plan.goal).toBeUndefined();
+    expect(plan.distance).toBeUndefined();
+    expect(plan.raceDate).toBeUndefined();
+  });
+
+  it("produces a plan that passes parsePlan", () => {
+    const template = getBuiltinTemplate("1-meso")!;
+    const plan = buildPlanFromTemplate(template, { block: "build", start: MONDAY });
+    expect(() => parsePlan(plan)).not.toThrow();
+  });
+
+  it("produces a plan that passes validatePlan", () => {
+    const template = getBuiltinTemplate("1-meso")!;
+    const plan = buildPlanFromTemplate(template, { block: "build", start: MONDAY });
+    const diagnostics = validatePlan(plan);
+    expect(diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/plan/build.ts
+++ b/packages/engine/src/plan/build.ts
@@ -1,0 +1,68 @@
+import type { PlanTemplate } from "./templates/types.js";
+import type { Plan } from "./schema.js";
+
+export interface BuildPlanOptions {
+  block: string;
+  start: string;
+  goal?: string;
+  distance?: string;
+  raceDate?: string;
+  weekStart?: string;
+}
+
+const DAY_NUMBERS: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function buildPlanFromTemplate(template: PlanTemplate, options: BuildPlanOptions): Plan {
+  const weekStartDay = options.weekStart ?? "monday";
+  const expectedDayNum = DAY_NUMBERS[weekStartDay];
+
+  if (expectedDayNum === undefined) {
+    throw new Error(`Invalid weekStart value: "${weekStartDay}"`);
+  }
+
+  const startDate = new Date(`${options.start}T00:00:00Z`);
+  if (startDate.getUTCDay() !== expectedDayNum) {
+    const actualDay = Object.keys(DAY_NUMBERS).find(
+      (k) => DAY_NUMBERS[k] === startDate.getUTCDay()
+    );
+    throw new Error(
+      `Start date ${options.start} does not fall on ${weekStartDay} (it's a ${actualDay})`
+    );
+  }
+
+  let weekIndex = 0;
+  const mesocycles = template.mesocycles.map((meso) => ({
+    name: meso.name,
+    fractals: meso.fractals.map((fractal) => ({
+      weeks: fractal.map((weekType) => {
+        const weekStart = addDays(options.start, weekIndex * 7);
+        weekIndex++;
+        return { planned: weekType, start: weekStart };
+      }),
+    })),
+  }));
+
+  return {
+    schemaVersion: 1,
+    block: options.block,
+    ...(options.goal !== undefined && { goal: options.goal }),
+    ...(options.distance !== undefined && { distance: options.distance }),
+    ...(options.raceDate !== undefined && { raceDate: options.raceDate }),
+    start: options.start,
+    mesocycles,
+  };
+}

--- a/packages/engine/src/plan/loader.test.ts
+++ b/packages/engine/src/plan/loader.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import { writeFile, mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadPlan } from "./loader.js";
+import { loadPlan, loadUserTemplates, resolveTemplate } from "./loader.js";
+import type { PlanTemplate } from "./templates/types.js";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), "run2max-loader-test-"));
@@ -80,5 +81,69 @@ mesocycles:
       expect(plan.raceDate).toBe("2026-10-18");
       expect(plan.mesocycles[0]!.fractals[0]!.weeks[0]!.testingPeriod?.cp).toBe(302);
     });
+  });
+});
+
+describe("loadUserTemplates", () => {
+  it("returns templates from directory", async () => {
+    await withTempDir(async (dir) => {
+      const yaml = `
+name: my-template
+description: A custom template
+mesocycles:
+  - name: MESO-1
+    fractals:
+      - [L, LL, D]
+`;
+      await writeFile(join(dir, "my-template.yaml"), yaml, "utf-8");
+      const templates = await loadUserTemplates(dir);
+      expect(templates).toHaveLength(1);
+      expect(templates[0]!.name).toBe("my-template");
+    });
+  });
+
+  it("returns empty array when directory does not exist", async () => {
+    const templates = await loadUserTemplates("/nonexistent/path/templates");
+    expect(templates).toEqual([]);
+  });
+
+  it("uses name field from YAML, not file name", async () => {
+    await withTempDir(async (dir) => {
+      const yaml = `
+name: canonical-name
+description: Template with a different canonical name
+mesocycles:
+  - name: MESO-1
+    fractals:
+      - [L, D]
+`;
+      await writeFile(join(dir, "file-name.yaml"), yaml, "utf-8");
+      const templates = await loadUserTemplates(dir);
+      expect(templates[0]!.name).toBe("canonical-name");
+    });
+  });
+});
+
+describe("resolveTemplate", () => {
+  it("user template overrides built-in on name collision", () => {
+    const customOneMeso: PlanTemplate = {
+      name: "1-meso",
+      description: "Custom override",
+      mesocycles: [{ name: "CUSTOM", fractals: [["L", "D"]] }],
+    };
+    const resolved = resolveTemplate("1-meso", [customOneMeso]);
+    expect(resolved!.description).toBe("Custom override");
+    expect(resolved!.mesocycles[0]!.name).toBe("CUSTOM");
+  });
+
+  it("falls back to built-in when no user template matches", () => {
+    const resolved = resolveTemplate("1-meso", []);
+    expect(resolved!.name).toBe("1-meso");
+    expect(resolved!.mesocycles).toHaveLength(1);
+  });
+
+  it("returns undefined for unknown template name", () => {
+    const resolved = resolveTemplate("nonexistent", []);
+    expect(resolved).toBeUndefined();
   });
 });

--- a/packages/engine/src/plan/loader.ts
+++ b/packages/engine/src/plan/loader.ts
@@ -1,6 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { parsePlan, type Plan } from "./schema.js";
+import type { PlanTemplate } from "./templates/types.js";
+import { getBuiltinTemplate } from "./templates/builtin.js";
 import * as v from "valibot";
 
 export async function loadPlan(filePath: string): Promise<Plan> {
@@ -35,4 +38,36 @@ export async function loadPlan(filePath: string): Promise<Plan> {
     }
     throw err;
   }
+}
+
+export async function loadUserTemplates(dirPath: string): Promise<PlanTemplate[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dirPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+
+  const yamlFiles = entries.filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+  const templates: PlanTemplate[] = [];
+
+  for (const file of yamlFiles) {
+    const contents = await readFile(join(dirPath, file), "utf-8");
+    const raw = parseYaml(contents) as PlanTemplate;
+    if (raw && typeof raw.name === "string") {
+      templates.push(raw);
+    }
+  }
+
+  return templates;
+}
+
+export function resolveTemplate(
+  name: string,
+  userTemplates: PlanTemplate[]
+): PlanTemplate | undefined {
+  return userTemplates.find((t) => t.name === name) ?? getBuiltinTemplate(name);
 }

--- a/packages/engine/src/smoke.test.ts
+++ b/packages/engine/src/smoke.test.ts
@@ -127,6 +127,7 @@ describe("smoke — real .fit file", () => {
       const ab = nodeBufferToArrayBuffer(buf);
 
       const config = {
+        schemaVersion: 1 as const,
         powerZones: [
           { label: "E", name: "Easy", min: 204, max: 233 },
           { label: "M", name: "Marathon", min: 251, max: 260 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,13 @@ importers:
       citty:
         specifier: ^0.1.6
         version: 0.1.6
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.3
     devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
Scaffold a plan.yaml from a template using CLI flags. No calendar reconciliation or interactive prompts — those are PR #13 .
This is the straightforward path: pick a template, provide metadata, get a plan.

Also fixes typescript checks for engine and cli

Resolves #12 