### PR TITLE
Adds plan status command

### DIFF
--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -7,6 +7,7 @@ export default defineCommand({
   },
   subCommands: {
     create: () => import("./create.js").then((m) => m.default),
+    status: () => import("./status.js").then((m) => m.default),
     validate: () => import("./validate.js").then((m) => m.default),
   },
 });

--- a/packages/cli/src/commands/plan/status.ts
+++ b/packages/cli/src/commands/plan/status.ts
@@ -1,0 +1,39 @@
+import { defineCommand } from "citty";
+import { join } from "node:path";
+import { loadPlan, getPlanStatus, formatDefaultView, formatFullView } from "@run2max/engine";
+
+export default defineCommand({
+  meta: {
+    name: "status",
+    description: "Show training plan status (current week focus or --full block overview)",
+  },
+  args: {
+    dir: {
+      type: "string",
+      description: "Directory containing plan.yaml (defaults to current directory)",
+      required: false,
+    },
+    full: {
+      type: "boolean",
+      description: "Show full block structural overview",
+      default: false,
+    },
+  },
+
+  async run({ args }) {
+    const dir = args.dir ?? process.cwd();
+    const filePath = join(dir, "plan.yaml");
+
+    let plan;
+    try {
+      plan = await loadPlan(filePath);
+    } catch (err) {
+      console.error(`error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const status = getPlanStatus(plan);
+    const output = args.full ? formatFullView(status) : formatDefaultView(status);
+    console.log(output);
+  },
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -76,6 +76,8 @@ export { buildPlanFromTemplate } from "./plan/build.js";
 export type { BuildPlanOptions } from "./plan/build.js";
 export { reconcile } from "./plan/reconcile.js";
 export type { ReconcileOptions, ReconciliationResult, CompressionOption } from "./plan/reconcile.js";
+export { getPlanStatus, formatDefaultView, formatFullView } from "./plan/status.js";
+export type { PlanStatus, WeekStatusEntry, NextMilestone, WeekMarker } from "./plan/status.js";
 
 // ---------------------------------------------------------------------------
 // Plan templates

--- a/packages/engine/src/plan/status.test.ts
+++ b/packages/engine/src/plan/status.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from "vitest";
+import { parsePlan } from "./schema.js";
+import { getPlanStatus, formatDefaultView, formatFullView } from "./status.js";
+
+// Fixed date for deterministic tests
+const TODAY = "2026-07-10";
+
+function makeSingleFractalPlan(weeks: object[], extras?: object) {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    start: "2026-05-04",
+    ...extras,
+    mesocycles: [{ name: "CANAL", fractals: [{ weeks }] }],
+  });
+}
+
+/**
+ * Multi-mesocycle plan used for structural and full-view tests.
+ * Week sequence (absolute index):
+ *   CANAL / F1: L(1)ok  LL(2)ok  LLL(3)ok  D(4)ok  Ta(5)ok  Tb(6)ok
+ *   CANAL / F2: L(7)current  LL(8)unsynced_past  LLL(9)unsynced_past
+ *               D(10)future  Ta(11)future  Tb(12)future
+ *   TAPER / F1: P(13).  P(14).  R(15).  N(16).
+ *
+ * TODAY = "2026-07-10"
+ * week end dates after current:
+ *   LL  starts 2026-06-22, end 2026-06-29 → past   → unsynced_past
+ *   LLL starts 2026-06-29, end 2026-07-06 → past   → unsynced_past
+ *   D   starts 2026-07-06, end 2026-07-13 → >=TODAY → future
+ */
+function makeFullPlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Santiago",
+    race_date: "2026-10-18",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L", start: "2026-05-04", executed: "L" },
+              { planned: "LL", start: "2026-05-11", executed: "LL" },
+              { planned: "LLL", start: "2026-05-18", executed: "LLL" },
+              { planned: "D", start: "2026-05-25", executed: "D" },
+              { planned: "Ta", start: "2026-06-01", executed: "Ta" },
+              { planned: "Tb", start: "2026-06-08", executed: "Tb" },
+            ],
+          },
+          {
+            weeks: [
+              { planned: "L", start: "2026-06-15" },   // 7 — current
+              { planned: "LL", start: "2026-06-22" },  // 8 — unsynced_past
+              { planned: "LLL", start: "2026-06-29" }, // 9 — unsynced_past
+              { planned: "D", start: "2026-07-06" },   // 10 — future
+              { planned: "Ta", start: "2026-07-13" },  // 11 — future
+              { planned: "Tb", start: "2026-07-20" },  // 12 — future
+            ],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-10-04" },  // 13 — future
+              { planned: "P", start: "2026-10-11" },  // 14 — future
+              { planned: "R", start: "2026-10-18" },  // 15 — future
+              { planned: "N", start: "2026-10-25" },  // 16 — future
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Engine computation tests
+// ---------------------------------------------------------------------------
+
+describe("getPlanStatus", () => {
+  it("identifies current week as first without executed", () => {
+    const plan = makeSingleFractalPlan([
+      { planned: "L", start: "2026-05-04", executed: "L" },
+      { planned: "LL", start: "2026-05-11", executed: "LL" },
+      { planned: "LLL", start: "2026-05-18" }, // first without executed
+      { planned: "D", start: "2026-05-25" },
+    ]);
+    const status = getPlanStatus(plan, "2026-05-22");
+    expect(status.currentWeek?.absoluteIndex).toBe(3);
+    expect(status.currentWeek?.planned).toBe("LLL");
+    expect(status.currentWeek?.marker).toBe("current");
+  });
+
+  it("returns completion state when all weeks have executed", () => {
+    const plan = makeSingleFractalPlan([
+      { planned: "L", start: "2026-05-04", executed: "L" },
+      { planned: "LL", start: "2026-05-11", executed: "LL" },
+    ]);
+    const status = getPlanStatus(plan, "2026-06-01");
+    expect(status.isComplete).toBe(true);
+    expect(status.currentWeek).toBeUndefined();
+    expect(status.nextMilestones).toHaveLength(0);
+    expect(status.unsyncedPastWeeks).toHaveLength(0);
+  });
+
+  it("computes correct week index (N of total)", () => {
+    const plan = parsePlan({
+      schema_version: 1,
+      block: "build",
+      start: "2026-05-04",
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            {
+              weeks: [
+                { planned: "L", start: "2026-05-04", executed: "L" },
+                { planned: "LL", start: "2026-05-11", executed: "LL" },
+                { planned: "LLL", start: "2026-05-18", executed: "LLL" },
+              ],
+            },
+            {
+              weeks: [
+                { planned: "D", start: "2026-05-25" }, // week 4 — current
+                { planned: "Ta", start: "2026-06-01" }, // week 5
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const status = getPlanStatus(plan, "2026-05-28");
+    expect(status.currentWeek?.absoluteIndex).toBe(4);
+    expect(status.currentWeek?.totalWeeks).toBe(5);
+    expect(status.totalWeeks).toBe(5);
+  });
+
+  it("computes correct mesocycle and fractal position", () => {
+    const plan = parsePlan({
+      schema_version: 1,
+      block: "build",
+      start: "2026-05-04",
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            { weeks: [{ planned: "L", start: "2026-05-04", executed: "L" }] },
+            { weeks: [{ planned: "LL", start: "2026-05-11" }] }, // current, F2 of 2
+          ],
+        },
+        {
+          name: "TAPER",
+          fractals: [
+            { weeks: [{ planned: "P", start: "2026-05-18" }] },
+          ],
+        },
+      ],
+    });
+    const status = getPlanStatus(plan, "2026-05-14");
+    expect(status.currentWeek?.mesocycleName).toBe("CANAL");
+    expect(status.currentWeek?.fractalIndex).toBe(2);
+    expect(status.currentWeek?.totalFractals).toBe(2);
+  });
+
+  it("marks synced matching weeks as ok", () => {
+    const plan = makeSingleFractalPlan([
+      { planned: "L", start: "2026-05-04", executed: "L" },
+      { planned: "LL", start: "2026-05-11", executed: "LL" },
+      { planned: "LLL", start: "2026-05-18" }, // current
+    ]);
+    const status = getPlanStatus(plan, "2026-05-22");
+    const synced = status.weeks.filter((w) => w.executed !== undefined);
+    expect(synced).toHaveLength(2);
+    expect(synced.every((w) => w.marker === "ok")).toBe(true);
+  });
+
+  it("marks deviated weeks with executed type, planned type, and reason", () => {
+    const plan = makeSingleFractalPlan([
+      {
+        planned: "LLL",
+        start: "2026-05-04",
+        executed: "INC",
+        reason: "illness",
+      },
+      { planned: "D", start: "2026-05-11" }, // current
+    ]);
+    const status = getPlanStatus(plan, "2026-05-14");
+    const deviated = status.weeks.find((w) => w.marker === "deviated");
+    expect(deviated).toBeDefined();
+    expect(deviated?.executed).toBe("INC");
+    expect(deviated?.planned).toBe("LLL");
+    expect(deviated?.reason).toBe("illness");
+  });
+
+  it("marks unsynced past weeks as unsynced_past (needs sync)", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const unsyncedPast = status.weeks.filter((w) => w.marker === "unsynced_past");
+    // weeks 8 (LL) and 9 (LLL) end before TODAY
+    expect(unsyncedPast).toHaveLength(2);
+    expect(unsyncedPast[0]?.absoluteIndex).toBe(8);
+    expect(unsyncedPast[1]?.absoluteIndex).toBe(9);
+    expect(status.unsyncedPastWeeks).toHaveLength(2);
+  });
+
+  it("marks future weeks as future (not yet reached)", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const future = status.weeks.filter((w) => w.marker === "future");
+    // weeks 10-16 (D, Ta, Tb in F2 + all of TAPER)
+    expect(future).toHaveLength(7);
+    expect(future[0]?.absoluteIndex).toBe(10);
+    expect(future[0]?.planned).toBe("D");
+  });
+
+  it("computes next milestones from current position", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    // current is week 7 (L), so next milestones are week 8 (LL) and week 9 (LLL)
+    expect(status.nextMilestones).toHaveLength(2);
+    expect(status.nextMilestones[0]?.weekIndex).toBe(8);
+    expect(status.nextMilestones[0]?.planned).toBe("LL");
+    expect(status.nextMilestones[0]?.weeksFromNow).toBe(1);
+    expect(status.nextMilestones[1]?.weekIndex).toBe(9);
+    expect(status.nextMilestones[1]?.planned).toBe("LLL");
+    expect(status.nextMilestones[1]?.weeksFromNow).toBe(2);
+  });
+
+  it("includes date context for current week", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    expect(status.currentWeek?.start).toBe("2026-06-15");
+  });
+
+  it("lists unsynced past weeks in default view data", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    expect(status.unsyncedPastWeeks).toHaveLength(2);
+    expect(status.unsyncedPastWeeks[0]?.planned).toBe("LL");
+    expect(status.unsyncedPastWeeks[1]?.planned).toBe("LLL");
+  });
+
+  it("handles plan with single mesocycle and single fractal", () => {
+    const plan = makeSingleFractalPlan([
+      { planned: "L", start: "2026-05-04" },
+    ]);
+    const status = getPlanStatus(plan, "2026-05-07");
+    expect(status.totalWeeks).toBe(1);
+    expect(status.currentWeek?.absoluteIndex).toBe(1);
+    expect(status.currentWeek?.fractalIndex).toBe(1);
+    expect(status.currentWeek?.totalFractals).toBe(1);
+    expect(status.isComplete).toBe(false);
+  });
+
+  it("handles plan with all weeks synced and some deviated", () => {
+    const plan = makeSingleFractalPlan([
+      { planned: "L", start: "2026-05-04", executed: "L" },
+      { planned: "LL", start: "2026-05-11", executed: "INC", reason: "travel" },
+      { planned: "LLL", start: "2026-05-18", executed: "LLL" },
+    ]);
+    const status = getPlanStatus(plan, "2026-06-01");
+    expect(status.isComplete).toBe(true);
+    const ok = status.weeks.filter((w) => w.marker === "ok");
+    const deviated = status.weeks.filter((w) => w.marker === "deviated");
+    expect(ok).toHaveLength(2);
+    expect(deviated).toHaveLength(1);
+    expect(deviated[0]?.reason).toBe("travel");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatting tests
+// ---------------------------------------------------------------------------
+
+describe("formatDefaultView", () => {
+  it("formats default view with header, position, and milestones", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatDefaultView(status);
+
+    expect(output).toContain("BUILD — Half Marathon Santiago (2026-10-18)");
+    expect(output).toContain("Mesocycle: CANAL | Fractal 2 of 2");
+    expect(output).toContain("Week 7/16 — L (2026-06-15)");
+    expect(output).toContain("Next:");
+  });
+
+  it("shows unsynced past weeks section when present", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatDefaultView(status);
+
+    expect(output).toContain("Unsynced:");
+    expect(output).toContain("Week 8/16 — LL (2026-06-22)");
+    expect(output).toContain("Week 9/16 — LLL (2026-06-29)");
+  });
+
+  it("shows plan complete message when all weeks have executed", () => {
+    const plan = makeSingleFractalPlan([
+      { planned: "L", start: "2026-05-04", executed: "L" },
+      { planned: "LL", start: "2026-05-11", executed: "LL" },
+    ]);
+    const status = getPlanStatus(plan, "2026-06-01");
+    const output = formatDefaultView(status);
+    expect(output).toContain("Plan complete");
+    expect(output).toContain("2");
+  });
+});
+
+describe("formatFullView", () => {
+  it("formats full view with all mesocycles and fractal rows", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatFullView(status);
+
+    expect(output).toContain("BUILD — Half Marathon Santiago (2026-10-18)");
+    expect(output).toContain("CANAL");
+    expect(output).toContain("TAPER");
+    expect(output).toContain("F1:");
+    expect(output).toContain("F2:");
+  });
+
+  it("full view shows current week marker", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatFullView(status);
+
+    expect(output).toContain("^ current");
+  });
+
+  it("formats ok weeks as 'planned ok'", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatFullView(status);
+
+    expect(output).toContain("L ok");
+    expect(output).toContain("LL ok");
+  });
+
+  it("formats deviated weeks as 'executed[planned/reason]'", () => {
+    const plan = parsePlan({
+      schema_version: 1,
+      block: "build",
+      start: "2026-05-04",
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            {
+              weeks: [
+                {
+                  planned: "LLL",
+                  start: "2026-05-04",
+                  executed: "INC",
+                  reason: "illness",
+                },
+                { planned: "D", start: "2026-05-11" }, // current
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const status = getPlanStatus(plan, "2026-05-14");
+    const output = formatFullView(status);
+    expect(output).toContain("INC[LLL/illness]");
+  });
+
+  it("formats unsynced past weeks with ? marker", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatFullView(status);
+    // LL and LLL in F2 are unsynced past
+    expect(output).toContain("LL?");
+    expect(output).toContain("LLL?");
+  });
+
+  it("formats future weeks with . marker", () => {
+    const plan = makeFullPlan();
+    const status = getPlanStatus(plan, TODAY);
+    const output = formatFullView(status);
+    expect(output).toContain("D .");
+    expect(output).toContain("P .");
+  });
+});

--- a/packages/engine/src/plan/status.ts
+++ b/packages/engine/src/plan/status.ts
@@ -1,0 +1,315 @@
+import type { Plan } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WeekMarker = "ok" | "deviated" | "current" | "unsynced_past" | "future";
+
+export interface WeekStatusEntry {
+  absoluteIndex: number;
+  totalWeeks: number;
+  mesocycleName: string;
+  fractalIndex: number;
+  totalFractals: number;
+  planned: string;
+  start: string;
+  executed?: string;
+  reason?: string;
+  marker: WeekMarker;
+}
+
+export interface NextMilestone {
+  weekIndex: number;
+  planned: string;
+  weeksFromNow: number;
+}
+
+export interface PlanStatus {
+  block: string;
+  goal?: string;
+  raceDate?: string;
+  totalWeeks: number;
+  isComplete: boolean;
+  currentWeek?: WeekStatusEntry;
+  nextMilestones: NextMilestone[];
+  unsyncedPastWeeks: WeekStatusEntry[];
+  weeks: WeekStatusEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Core computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the status of a training plan.
+ *
+ * @param plan  Parsed Plan object
+ * @param today ISO date string for "today" (defaults to actual current date).
+ *              Pass explicitly to make behaviour deterministic in tests.
+ */
+export function getPlanStatus(
+  plan: Plan,
+  today: string = new Date().toISOString().slice(0, 10),
+): PlanStatus {
+  // ------------------------------------------------------------------
+  // Flatten weeks with structural context
+  // ------------------------------------------------------------------
+  interface RawEntry {
+    absoluteIndex: number;
+    mesocycleName: string;
+    fractalIndex: number;
+    totalFractals: number;
+    planned: string;
+    start: string;
+    executed?: string;
+    reason?: string;
+  }
+
+  const raw: RawEntry[] = [];
+  let idx = 1;
+
+  for (const meso of plan.mesocycles) {
+    const totalFractals = meso.fractals.length;
+    let fi = 1;
+    for (const fractal of meso.fractals) {
+      for (const week of fractal.weeks) {
+        raw.push({
+          absoluteIndex: idx++,
+          mesocycleName: meso.name,
+          fractalIndex: fi,
+          totalFractals,
+          planned: week.planned,
+          start: week.start,
+          executed: week.executed,
+          reason: week.reason,
+        });
+      }
+      fi++;
+    }
+  }
+
+  const totalWeeks = raw.length;
+  const isComplete = raw.every((w) => w.executed !== undefined);
+
+  // First week without executed → current position in the plan
+  const currentIdx = isComplete ? -1 : raw.findIndex((w) => w.executed === undefined);
+
+  // ------------------------------------------------------------------
+  // Assign markers
+  // ------------------------------------------------------------------
+  const weeks: WeekStatusEntry[] = raw.map((w, i) => {
+    let marker: WeekMarker;
+
+    if (w.executed !== undefined) {
+      marker = w.executed === w.planned ? "ok" : "deviated";
+    } else if (i === currentIdx) {
+      marker = "current";
+    } else {
+      // Week without executed, after current — distinguish past from future
+      const weekEnd = addDays(w.start, 7);
+      marker = weekEnd < today ? "unsynced_past" : "future";
+    }
+
+    return {
+      absoluteIndex: w.absoluteIndex,
+      totalWeeks,
+      mesocycleName: w.mesocycleName,
+      fractalIndex: w.fractalIndex,
+      totalFractals: w.totalFractals,
+      planned: w.planned,
+      start: w.start,
+      executed: w.executed,
+      reason: w.reason,
+      marker,
+    };
+  });
+
+  if (isComplete) {
+    return {
+      block: plan.block,
+      goal: plan.goal,
+      raceDate: plan.raceDate,
+      totalWeeks,
+      isComplete: true,
+      nextMilestones: [],
+      unsyncedPastWeeks: [],
+      weeks,
+    };
+  }
+
+  const currentWeek = weeks[currentIdx]!;
+
+  // Next 2 milestones after the current week
+  const nextMilestones: NextMilestone[] = [];
+  for (let i = currentIdx + 1; i < weeks.length && nextMilestones.length < 2; i++) {
+    nextMilestones.push({
+      weekIndex: weeks[i]!.absoluteIndex,
+      planned: weeks[i]!.planned,
+      weeksFromNow: i - currentIdx,
+    });
+  }
+
+  const unsyncedPastWeeks = weeks.filter((w) => w.marker === "unsynced_past");
+
+  return {
+    block: plan.block,
+    goal: plan.goal,
+    raceDate: plan.raceDate,
+    totalWeeks,
+    isComplete: false,
+    currentWeek,
+    nextMilestones,
+    unsyncedPastWeeks,
+    weeks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers (shared between default and full views)
+// ---------------------------------------------------------------------------
+
+function buildHeader(status: PlanStatus): string {
+  let header = status.block.toUpperCase();
+  if (status.goal) {
+    header += ` — ${status.goal}`;
+    if (status.raceDate) {
+      header += ` (${status.raceDate})`;
+    }
+  }
+  return header;
+}
+
+function relativeLabel(weeksFromNow: number): string {
+  return weeksFromNow === 1 ? "next week" : `in ${weeksFromNow} weeks`;
+}
+
+/** Token for a week entry in the full structural view. */
+function weekToFullToken(w: WeekStatusEntry): string {
+  switch (w.marker) {
+    case "ok":
+      return `${w.planned} ok`;
+    case "deviated": {
+      const suffix = w.reason ? `/${w.reason}` : "";
+      return `${w.executed}[${w.planned}${suffix}]`;
+    }
+    case "current":
+      // No suffix — distinguished by the `^ current` line below
+      return w.planned;
+    case "unsynced_past":
+      return `${w.planned}?`;
+    case "future":
+      return `${w.planned} .`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default view
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats the default (current-week-focused) plan status view.
+ */
+export function formatDefaultView(status: PlanStatus): string {
+  const lines: string[] = [];
+
+  lines.push(buildHeader(status));
+
+  if (status.isComplete) {
+    lines.push(`Plan complete. All ${status.totalWeeks} weeks executed.`);
+    return lines.join("\n");
+  }
+
+  const cw = status.currentWeek!;
+
+  lines.push(`Mesocycle: ${cw.mesocycleName} | Fractal ${cw.fractalIndex} of ${cw.totalFractals}`);
+  lines.push("");
+  lines.push(`Week ${cw.absoluteIndex}/${cw.totalWeeks} — ${cw.planned} (${cw.start})`);
+
+  if (status.nextMilestones.length > 0) {
+    const [first, second] = status.nextMilestones;
+    if (second) {
+      lines.push(
+        `  Next: ${first!.planned} (${relativeLabel(first!.weeksFromNow)}) → ${second.planned} in ${second.weeksFromNow} weeks`,
+      );
+    } else {
+      lines.push(`  Next: ${first!.planned} (${relativeLabel(first!.weeksFromNow)})`);
+    }
+  }
+
+  if (status.unsyncedPastWeeks.length > 0) {
+    lines.push("");
+    lines.push("Unsynced:");
+    for (const w of status.unsyncedPastWeeks) {
+      lines.push(`  Week ${w.absoluteIndex}/${w.totalWeeks} — ${w.planned} (${w.start})`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Full view
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats the full structural overview of the plan.
+ * Each mesocycle is shown with its fractals; each week has a status marker.
+ * The current week is identified with a `^ current` caret on the line below.
+ */
+export function formatFullView(status: PlanStatus): string {
+  const lines: string[] = [];
+
+  lines.push(buildHeader(status));
+
+  // Group weeks into mesocycle → fractal buckets preserving plan order
+  interface MesoGroup {
+    name: string;
+    fractals: WeekStatusEntry[][];
+  }
+  const mesoGroups: MesoGroup[] = [];
+
+  for (const w of status.weeks) {
+    let meso = mesoGroups.find((m) => m.name === w.mesocycleName);
+    if (!meso) {
+      meso = { name: w.mesocycleName, fractals: [] };
+      mesoGroups.push(meso);
+    }
+    const fi = w.fractalIndex - 1; // 0-based
+    while (meso.fractals.length <= fi) meso.fractals.push([]);
+    meso.fractals[fi]!.push(w);
+  }
+
+  for (const meso of mesoGroups) {
+    lines.push("");
+    lines.push(meso.name);
+
+    meso.fractals.forEach((fractalWeeks, fi) => {
+      const prefix = `  F${fi + 1}: `;
+      const tokens = fractalWeeks.map(weekToFullToken);
+      lines.push(prefix + tokens.join("  "));
+
+      const currentIdx = fractalWeeks.findIndex((w) => w.marker === "current");
+      if (currentIdx >= 0) {
+        // Compute character column of the current week token
+        let col = prefix.length;
+        for (let i = 0; i < currentIdx; i++) {
+          col += tokens[i]!.length + 2; // token + 2-space separator
+        }
+        lines.push(" ".repeat(col) + "^ current");
+      }
+    });
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Shows the athlete where they are in their training block — current week focus (default) or full block structural overview (--full). 

Resolves #14 