### PR TITLE
Adds plan adjust command

### DIFF
--- a/packages/cli/src/commands/plan/adjust.ts
+++ b/packages/cli/src/commands/plan/adjust.ts
@@ -1,0 +1,238 @@
+import { defineCommand } from "citty";
+import { join } from "node:path";
+import { writeFile } from "node:fs/promises";
+import { stringify as stringifyYaml } from "yaml";
+import { consola } from "consola";
+import {
+  loadPlan,
+  validatePlan,
+  getPlanStatus,
+  formatFullView,
+  adjustPlan,
+  AdjustError,
+} from "@run2max/engine";
+import type { Plan } from "@run2max/engine";
+
+// ---------------------------------------------------------------------------
+// Serialization helpers (mirrors sync.ts)
+// ---------------------------------------------------------------------------
+
+function planToYaml(plan: Plan): Record<string, unknown> {
+  return {
+    schema_version: plan.schemaVersion,
+    block: plan.block,
+    ...(plan.goal !== undefined ? { goal: plan.goal } : {}),
+    ...(plan.distance !== undefined ? { distance: plan.distance } : {}),
+    ...(plan.raceDate !== undefined ? { race_date: plan.raceDate } : {}),
+    start: plan.start,
+    mesocycles: plan.mesocycles.map((meso) => ({
+      name: meso.name,
+      fractals: meso.fractals.map((fractal) => ({
+        weeks: fractal.weeks.map((week) => ({
+          planned: week.planned,
+          start: week.start,
+          ...(week.executed !== undefined ? { executed: week.executed } : {}),
+          ...(week.reason !== undefined ? { reason: week.reason } : {}),
+          ...(week.note !== undefined ? { note: week.note } : {}),
+          ...(week.testingPeriod !== undefined
+            ? {
+                testing_period: {
+                  ...(week.testingPeriod.cp !== undefined ? { cp: week.testingPeriod.cp } : {}),
+                  ...(week.testingPeriod.eFtp !== undefined
+                    ? { e_ftp: week.testingPeriod.eFtp }
+                    : {}),
+                  ...(week.testingPeriod.lthr !== undefined
+                    ? { lthr: week.testingPeriod.lthr }
+                    : {}),
+                  ...(week.testingPeriod.zones !== undefined
+                    ? { zones: week.testingPeriod.zones }
+                    : {}),
+                },
+              }
+            : {}),
+        })),
+      })),
+    })),
+  } as Record<string, unknown>;
+}
+
+async function savePlan(filePath: string, plan: Plan): Promise<void> {
+  const raw = planToYaml(plan);
+  const yaml = stringifyYaml(raw, { lineWidth: 100 });
+  await writeFile(filePath, yaml, "utf-8");
+}
+
+function validateAndReport(plan: Plan): boolean {
+  const diagnostics = validatePlan(plan);
+  if (diagnostics.length > 0) {
+    for (const d of diagnostics) {
+      const loc = d.path ? ` (${d.path})` : "";
+      consola.warn(`validation: ${d.message}${loc}`);
+    }
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Preview helpers
+// ---------------------------------------------------------------------------
+
+function renderFullView(plan: Plan): string {
+  return formatFullView(getPlanStatus(plan));
+}
+
+function printBeforeAfter(before: Plan, after: Plan): void {
+  consola.log("\nCurrent plan:");
+  for (const line of renderFullView(before).split("\n")) {
+    consola.log("  " + line);
+  }
+  consola.log("\nAfter adjustment:");
+  for (const line of renderFullView(after).split("\n")) {
+    consola.log("  " + line);
+  }
+  consola.log("");
+}
+
+// ---------------------------------------------------------------------------
+// CLI command
+// ---------------------------------------------------------------------------
+
+export default defineCommand({
+  meta: {
+    name: "adjust",
+    description:
+      "Restructure future weeks — re-reconcile when race date changes or apply a compression strategy",
+  },
+  args: {
+    dir: {
+      type: "string",
+      description: "Directory containing plan.yaml (defaults to current directory)",
+      required: false,
+    },
+    "race-date": {
+      type: "string",
+      description: "New race date (YYYY-MM-DD) — re-reconciles future weeks",
+      required: false,
+    },
+    strategy: {
+      type: "string",
+      description:
+        "Compression strategy: shorten-taper | reduce-transition | shorten-fractal | reduce-testing | skip-testing | drop-fractal",
+      required: false,
+    },
+    yes: {
+      type: "boolean",
+      description: "Skip confirmation prompt (useful for scripting)",
+      required: false,
+      default: false,
+    },
+  },
+
+  async run({ args }) {
+    const dir = args.dir ?? process.cwd();
+    const filePath = join(dir, "plan.yaml");
+
+    let plan: Plan;
+    try {
+      plan = await loadPlan(filePath);
+    } catch (err) {
+      consola.error((err as Error).message);
+      process.exit(1);
+    }
+
+    const raceDate = args["race-date"] as string | undefined;
+    const strategy = args.strategy as string | undefined;
+    const skipConfirm = args.yes as boolean;
+
+    // ── Informational mode (no flags) ────────────────────────────────────────
+
+    if (raceDate === undefined && strategy === undefined) {
+      let result;
+      try {
+        result = adjustPlan(plan, {});
+      } catch (err) {
+        if (err instanceof AdjustError) {
+          consola.error(err.message);
+        } else {
+          consola.error((err as Error).message);
+        }
+        process.exit(1);
+      }
+
+      if (result.mode !== "info") {
+        consola.error("unexpected result mode");
+        process.exit(1);
+      }
+
+      consola.log(renderFullView(plan));
+      consola.log("");
+      consola.info(
+        `${result.frozenWeeks} frozen week(s), ${result.adjustableWeeks} adjustable week(s)`,
+      );
+
+      if (result.currentRaceDate) {
+        consola.info(`Race date: ${result.currentRaceDate}`);
+      }
+
+      if (result.availableStrategies.length > 0) {
+        consola.log("\nAvailable adjustments:");
+        for (const opt of result.availableStrategies) {
+          const warnings =
+            opt.warnings.length > 0 ? ` [warning: ${opt.warnings.join("; ")}]` : "";
+          consola.log(
+            `  --strategy ${opt.strategies.join("+")}  (removes ${opt.weeksRemoved} week(s))${warnings}`,
+          );
+        }
+      } else {
+        consola.info("No compression strategies available for this plan.");
+      }
+
+      return;
+    }
+
+    // ── Strategy / race-date mode ─────────────────────────────────────────────
+
+    let adjustResult;
+    try {
+      adjustResult = adjustPlan(plan, { strategy, raceDate });
+    } catch (err) {
+      if (err instanceof AdjustError) {
+        consola.error(err.message);
+      } else {
+        consola.error((err as Error).message);
+      }
+      process.exit(1);
+    }
+
+    if (adjustResult.mode !== "plan") {
+      consola.error("unexpected result mode");
+      process.exit(1);
+    }
+
+    const updatedPlan = adjustResult.plan;
+
+    // Show before/after preview
+    printBeforeAfter(plan, updatedPlan);
+
+    // Confirm unless --yes
+    if (!skipConfirm) {
+      const confirmed = await consola.prompt("Apply these changes?", {
+        type: "confirm",
+        initial: false,
+      });
+      if (!confirmed) {
+        consola.info("Aborted — no changes written");
+        return;
+      }
+    }
+
+    validateAndReport(updatedPlan);
+    await savePlan(filePath, updatedPlan);
+
+    const changeDesc = raceDate
+      ? `race date changed to ${raceDate}`
+      : `strategy "${strategy}" applied`;
+    consola.success(`Plan adjusted: ${changeDesc}`);
+  },
+});

--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -9,6 +9,7 @@ export default defineCommand({
     create: () => import("./create.js").then((m) => m.default),
     status: () => import("./status.js").then((m) => m.default),
     sync: () => import("./sync.js").then((m) => m.default),
+    adjust: () => import("./adjust.js").then((m) => m.default),
     validate: () => import("./validate.js").then((m) => m.default),
   },
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -80,6 +80,8 @@ export { getPlanStatus, formatDefaultView, formatFullView } from "./plan/status.
 export type { PlanStatus, WeekStatusEntry, NextMilestone, WeekMarker } from "./plan/status.js";
 export { syncWeek, SyncError } from "./plan/sync.js";
 export type { SyncData } from "./plan/sync.js";
+export { adjustPlan, AdjustError } from "./plan/adjust.js";
+export type { AdjustOptions, AdjustResult } from "./plan/adjust.js";
 
 // ---------------------------------------------------------------------------
 // Plan templates

--- a/packages/engine/src/plan/adjust.test.ts
+++ b/packages/engine/src/plan/adjust.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect } from "vitest";
+import { parsePlan } from "./schema.js";
+import { validatePlan } from "./validate.js";
+import { adjustPlan, AdjustError } from "./adjust.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Base plan: 4 executed weeks in CANAL F1, TAPER F1 [P,P,R,N] as future.
+ * race_date = 2026-06-15 → EXACT FIT (availableWeeks=3, weeksBeforeR=3).
+ */
+function makeBasePlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Test",
+    distance: "half-marathon",
+    race_date: "2026-06-15",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L", start: "2026-05-04", executed: "L" },
+              { planned: "LL", start: "2026-05-11", executed: "LL" },
+              {
+                planned: "D",
+                start: "2026-05-18",
+                executed: "INC",
+                reason: "illness",
+              },
+              { planned: "Ta", start: "2026-05-25", executed: "Ta" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-06-01" },
+              { planned: "P", start: "2026-06-08" },
+              { planned: "R", start: "2026-06-15" },
+              { planned: "N", start: "2026-06-22" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/**
+ * Overflow plan: same structure but race_date = 2026-06-08.
+ * Overflow by 1 (weeksBeforeR=3, availableWeeks=2).
+ * shorten-taper fixes it (weeksBeforeR=2, exact fit).
+ */
+function makeOverflowPlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Test",
+    distance: "half-marathon",
+    race_date: "2026-06-08",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L", start: "2026-05-04", executed: "L" },
+              { planned: "LL", start: "2026-05-11", executed: "LL" },
+              { planned: "D", start: "2026-05-18", executed: "D" },
+              { planned: "Ta", start: "2026-05-25", executed: "Ta" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-06-01" },
+              { planned: "P", start: "2026-06-08" },
+              { planned: "R", start: "2026-06-15" },
+              { planned: "N", start: "2026-06-22" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/**
+ * Drop-fractal overflow plan:
+ * CANAL F1 (executed) + CANAL F2 [L,LL,LLL,D,Ta] (future) + TAPER [P,R,N] (future).
+ * race_date = 2026-07-06.
+ * availableWeeks=6, weeksBeforeR=7 → overflow by 1.
+ * After drop-fractal: CANAL F2 dropped. TAPER fits (underflow). ✓
+ */
+function makeDropFractalPlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Test",
+    distance: "half-marathon",
+    race_date: "2026-07-06",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L", start: "2026-05-04", executed: "L" },
+              { planned: "LL", start: "2026-05-11", executed: "LL" },
+              { planned: "D", start: "2026-05-18", executed: "D" },
+              { planned: "Ta", start: "2026-05-25", executed: "Ta" },
+            ],
+          },
+          {
+            weeks: [
+              { planned: "L", start: "2026-06-01" },
+              { planned: "LL", start: "2026-06-08" },
+              { planned: "LLL", start: "2026-06-15" },
+              { planned: "D", start: "2026-06-22" },
+              { planned: "Ta", start: "2026-06-29" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-07-06" },
+              { planned: "R", start: "2026-07-13" },
+              { planned: "N", start: "2026-07-20" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/**
+ * Impossible-strategy plan:
+ * CANAL F2 [L] (future) + TAPER [P,R,N] (future), race_date = 2026-06-08.
+ * availableWeeks=2, weeksBeforeR=3 → overflow by 1.
+ * shorten-taper fails (only 1P in TAPER) → error.
+ */
+function makeImpossibleStrategyPlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    race_date: "2026-06-08",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L", start: "2026-05-04", executed: "L" },
+              { planned: "LL", start: "2026-05-11", executed: "LL" },
+              { planned: "D", start: "2026-05-18", executed: "D" },
+              { planned: "Ta", start: "2026-05-25", executed: "Ta" },
+            ],
+          },
+          {
+            weeks: [{ planned: "L", start: "2026-06-01" }],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-06-08" },
+              { planned: "R", start: "2026-06-15" },
+              { planned: "N", start: "2026-06-22" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/** All weeks executed — no future weeks. */
+function makeFullyExecutedPlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    race_date: "2026-06-15",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L", start: "2026-05-04", executed: "L" },
+              { planned: "LL", start: "2026-05-11", executed: "LL" },
+              { planned: "D", start: "2026-05-18", executed: "D" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-05-25", executed: "P" },
+              { planned: "R", start: "2026-06-01", executed: "R" },
+              { planned: "N", start: "2026-06-08", executed: "N" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("adjustPlan", () => {
+  // ── frozen history ────────────────────────────────────────────────────────
+
+  it("preserves all executed weeks unchanged", () => {
+    const plan = makeOverflowPlan();
+    const result = adjustPlan(plan, { strategy: "shorten-taper" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    const canal = result.plan.mesocycles[0]!;
+    const frozenWeeks = canal.fractals[0]!.weeks;
+
+    expect(frozenWeeks[0]!.executed).toBe("L");
+    expect(frozenWeeks[0]!.planned).toBe("L");
+    expect(frozenWeeks[1]!.executed).toBe("LL");
+    expect(frozenWeeks[2]!.executed).toBe("D");
+    expect(frozenWeeks[3]!.executed).toBe("Ta");
+  });
+
+  // ── strategy application ──────────────────────────────────────────────────
+
+  it("applies shorten-taper to future weeks", () => {
+    const plan = makeOverflowPlan();
+    const result = adjustPlan(plan, { strategy: "shorten-taper" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    // TAPER should now have 3 weeks: [P, R, N]
+    const taper = result.plan.mesocycles.find(m => m.name === "TAPER")!;
+    expect(taper).toBeDefined();
+    const taperWeeks = taper.fractals[0]!.weeks;
+    expect(taperWeeks).toHaveLength(3);
+    expect(taperWeeks.map(w => w.planned)).toEqual(["P", "R", "N"]);
+  });
+
+  it("applies drop-fractal to future weeks", () => {
+    const plan = makeDropFractalPlan();
+    const result = adjustPlan(plan, { strategy: "drop-fractal" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    // CANAL should only have F1 (the frozen fractal)
+    const canal = result.plan.mesocycles.find(m => m.name === "CANAL")!;
+    expect(canal).toBeDefined();
+    expect(canal.fractals).toHaveLength(1);
+    // F1 stays frozen (4 executed weeks)
+    expect(canal.fractals[0]!.weeks).toHaveLength(4);
+
+    // TAPER should still be present
+    const taper = result.plan.mesocycles.find(m => m.name === "TAPER")!;
+    expect(taper).toBeDefined();
+    expect(taper.fractals[0]!.weeks.map(w => w.planned)).toEqual([
+      "P",
+      "R",
+      "N",
+    ]);
+  });
+
+  // ── race date re-reconciliation ───────────────────────────────────────────
+
+  it("re-reconciles when race date changes", () => {
+    // race_date moves 1 week later (06-15 → 06-22): underflow → still fits
+    const plan = makeBasePlan();
+    const result = adjustPlan(plan, { raceDate: "2026-06-22" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    // Plan should reflect new race date
+    expect(result.plan.raceDate).toBe("2026-06-22");
+
+    // R week should be on the new race date
+    const rWeek = result.plan.mesocycles
+      .flatMap(m => m.fractals.flatMap(f => f.weeks))
+      .find(w => w.planned === "R");
+    expect(rWeek?.start).toBe("2026-06-22");
+  });
+
+  // ── error cases ───────────────────────────────────────────────────────────
+
+  it("errors when no future weeks exist", () => {
+    const plan = makeFullyExecutedPlan();
+    expect(() => adjustPlan(plan, { strategy: "shorten-taper" })).toThrow(
+      AdjustError,
+    );
+
+    try {
+      adjustPlan(plan, { strategy: "shorten-taper" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdjustError);
+      expect((err as AdjustError).code).toBe("NO_FUTURE_WEEKS");
+    }
+  });
+
+  it("errors when strategy doesn't fit", () => {
+    // TAPER has only 1P — shorten-taper returns null → impossible
+    const plan = makeImpossibleStrategyPlan();
+    expect(() => adjustPlan(plan, { strategy: "shorten-taper" })).toThrow(
+      AdjustError,
+    );
+
+    try {
+      adjustPlan(plan, { strategy: "shorten-taper" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdjustError);
+      expect((err as AdjustError).code).toBe("STRATEGY_IMPOSSIBLE");
+    }
+  });
+
+  // ── informational mode ────────────────────────────────────────────────────
+
+  it("lists available strategies when none specified", () => {
+    const plan = makeBasePlan();
+    const result = adjustPlan(plan, {});
+
+    expect(result.mode).toBe("info");
+    if (result.mode !== "info") throw new Error("expected info mode");
+
+    expect(result.frozenWeeks).toBe(4);
+    expect(result.adjustableWeeks).toBe(4);
+    expect(result.currentRaceDate).toBe("2026-06-15");
+    // availableStrategies is an array (may be empty for exact-fit plan)
+    expect(Array.isArray(result.availableStrategies)).toBe(true);
+  });
+
+  // ── output validity ───────────────────────────────────────────────────────
+
+  it("adjusted plan passes parsePlan and validatePlan", () => {
+    const plan = makeOverflowPlan();
+    const result = adjustPlan(plan, { strategy: "shorten-taper" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    // Re-serialize and re-parse to verify round-trip validity
+    const p = result.plan;
+    const reparsed = parsePlan({
+      schema_version: 1,
+      block: p.block,
+      ...(p.goal !== undefined ? { goal: p.goal } : {}),
+      ...(p.distance !== undefined ? { distance: p.distance } : {}),
+      ...(p.raceDate !== undefined ? { race_date: p.raceDate } : {}),
+      start: p.start,
+      mesocycles: p.mesocycles.map(m => ({
+        name: m.name,
+        fractals: m.fractals.map(f => ({
+          weeks: f.weeks.map(w => ({
+            planned: w.planned,
+            start: w.start,
+            ...(w.executed !== undefined ? { executed: w.executed } : {}),
+            ...(w.reason !== undefined ? { reason: w.reason } : {}),
+            ...(w.note !== undefined ? { note: w.note } : {}),
+          })),
+        })),
+      })),
+    });
+
+    const diagnostics = validatePlan(reparsed);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  // ── date reassignment ─────────────────────────────────────────────────────
+
+  it("recalculates all future week start dates when race date changes", () => {
+    const plan = makeBasePlan();
+    const result = adjustPlan(plan, { raceDate: "2026-06-22" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    const allWeeks = result.plan.mesocycles.flatMap(m =>
+      m.fractals.flatMap(f => f.weeks),
+    );
+    const futureWeeks = allWeeks.filter(w => w.executed === undefined);
+
+    // R must be on the new race date
+    const rWeek = futureWeeks.find(w => w.planned === "R");
+    expect(rWeek?.start).toBe("2026-06-22");
+
+    // All future week dates are Mondays (spaced 7 days apart)
+    const futureStarts = futureWeeks.map(w => w.start);
+    for (let i = 1; i < futureStarts.length; i++) {
+      const prev = new Date(futureStarts[i - 1]! + "T00:00:00Z");
+      const curr = new Date(futureStarts[i]! + "T00:00:00Z");
+      const diff = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diff).toBe(7);
+    }
+  });
+
+  // ── note preservation ─────────────────────────────────────────────────────
+
+  it("preserves notes on future weeks when structure is unchanged", () => {
+    // Add a note to a future P week, then adjust race date (no structural change)
+    const plan = parsePlan({
+      schema_version: 1,
+      block: "build",
+      race_date: "2026-06-15",
+      start: "2026-05-04",
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            {
+              weeks: [
+                { planned: "L", start: "2026-05-04", executed: "L" },
+                { planned: "LL", start: "2026-05-11", executed: "LL" },
+                { planned: "D", start: "2026-05-18", executed: "D" },
+                { planned: "Ta", start: "2026-05-25", executed: "Ta" },
+              ],
+            },
+          ],
+        },
+        {
+          name: "TAPER",
+          fractals: [
+            {
+              weeks: [
+                { planned: "P", start: "2026-06-01", note: "key shakeout" },
+                { planned: "P", start: "2026-06-08" },
+                { planned: "R", start: "2026-06-15" },
+                { planned: "N", start: "2026-06-22" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    // Race date moves 1 week later (same structure: [P, P, R, N])
+    const result = adjustPlan(plan, { raceDate: "2026-06-22" });
+
+    if (result.mode !== "plan") throw new Error("expected plan mode");
+
+    const taperWeeks = result.plan.mesocycles.find(m => m.name === "TAPER")!
+      .fractals[0]!.weeks;
+
+    // First P week should still have its note
+    expect(taperWeeks[0]!.planned).toBe("P");
+    expect(taperWeeks[0]!.note).toBe("key shakeout");
+  });
+
+  // ── boundary condition ────────────────────────────────────────────────────
+
+  it("current week (first without executed) is adjustable", () => {
+    // The first TAPER week is the current week. It should be included in adjustable weeks.
+    const plan = makeBasePlan();
+    const result = adjustPlan(plan, {});
+
+    if (result.mode !== "info") throw new Error("expected info mode");
+
+    // 4 executed weeks (CANAL F1), 4 adjustable weeks (TAPER F1)
+    expect(result.adjustableWeeks).toBe(4);
+    // Current week (first TAPER P) is in the adjustable set → adjustableWeeks >= 1
+    expect(result.adjustableWeeks).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/engine/src/plan/adjust.ts
+++ b/packages/engine/src/plan/adjust.ts
@@ -1,0 +1,391 @@
+import type { Plan } from "./schema.js";
+import type { PlanTemplate } from "./templates/types.js";
+import { reconcile } from "./reconcile.js";
+import type { CompressionOption } from "./reconcile.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface AdjustOptions {
+  strategy?: string;
+  raceDate?: string;
+  weekStart?: string;
+  distance?: string;
+}
+
+export type AdjustResult =
+  | { mode: "plan"; plan: Plan }
+  | {
+      mode: "info";
+      frozenWeeks: number;
+      adjustableWeeks: number;
+      availableStrategies: CompressionOption[];
+      currentRaceDate?: string;
+    };
+
+export class AdjustError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = "AdjustError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface FlatWeek {
+  absoluteIndex: number; // 1-based
+  mesoIndex: number;
+  fractalIndex: number;
+  weekIndex: number;
+  planned: string;
+  start: string;
+  executed?: string;
+  note?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flattenWeeks(plan: Plan): FlatWeek[] {
+  const result: FlatWeek[] = [];
+  let idx = 1;
+
+  for (let mi = 0; mi < plan.mesocycles.length; mi++) {
+    const meso = plan.mesocycles[mi]!;
+    for (let fi = 0; fi < meso.fractals.length; fi++) {
+      const fractal = meso.fractals[fi]!;
+      for (let wi = 0; wi < fractal.weeks.length; wi++) {
+        const week = fractal.weeks[wi]!;
+        result.push({
+          absoluteIndex: idx++,
+          mesoIndex: mi,
+          fractalIndex: fi,
+          weekIndex: wi,
+          planned: week.planned,
+          start: week.start,
+          executed: week.executed,
+          note: week.note,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Builds a PlanTemplate from the adjustable (future) portion of the plan.
+ * Preserves mesocycle names and fractal groupings.
+ *
+ * If the frontier falls in the middle of a fractal, the boundary fractal's
+ * future weeks form the first (partial) fractal of the frontier mesocycle.
+ */
+function extractFutureTemplate(
+  plan: Plan,
+  flatWeeks: FlatWeek[],
+  frontierIdx: number,
+): PlanTemplate {
+  const frontier = flatWeeks[frontierIdx]!;
+  const { mesoIndex: fMi, fractalIndex: fFi, weekIndex: fWi } = frontier;
+
+  const mesocycles: PlanTemplate["mesocycles"] = [];
+
+  for (let mi = fMi; mi < plan.mesocycles.length; mi++) {
+    const meso = plan.mesocycles[mi]!;
+    const startFi = mi === fMi ? fFi : 0;
+    const fractals: string[][] = [];
+
+    for (let fi = startFi; fi < meso.fractals.length; fi++) {
+      const fractal = meso.fractals[fi]!;
+      const startWi = mi === fMi && fi === fFi ? fWi : 0;
+      const weekTypes = fractal.weeks.slice(startWi).map((w) => w.planned);
+      if (weekTypes.length > 0) {
+        fractals.push(weekTypes);
+      }
+    }
+
+    if (fractals.length > 0) {
+      mesocycles.push({ name: meso.name, fractals });
+    }
+  }
+
+  return { name: "future", description: "extracted future portion", mesocycles };
+}
+
+/**
+ * Deep-clones a Plan (structural copy sufficient for immutable updates).
+ */
+function clonePlan(plan: Plan): Plan {
+  return {
+    ...plan,
+    mesocycles: plan.mesocycles.map((meso) => ({
+      ...meso,
+      fractals: meso.fractals.map((fractal) => ({
+        ...fractal,
+        weeks: fractal.weeks.map((week) => ({ ...week })),
+      })),
+    })),
+  };
+}
+
+/**
+ * Merges the frozen (executed) portion of the original plan with the
+ * reconciled future plan, returning a complete updated plan.
+ *
+ * The frontier is the first week without `executed`. Everything before it
+ * is frozen; everything from it onward comes from the reconciled future plan.
+ */
+function mergeFrozenAndFuture(
+  originalPlan: Plan,
+  flatWeeks: FlatWeek[],
+  frontierIdx: number,
+  futurePlan: Plan,
+  newRaceDate?: string,
+): Plan {
+  const frontier = flatWeeks[frontierIdx]!;
+  const { mesoIndex: fMi, fractalIndex: fFi, weekIndex: fWi } = frontier;
+
+  // Build the frozen mesocycles that come entirely before the frontier mesocycle
+  const outputMesos: Plan["mesocycles"] = [];
+
+  for (let mi = 0; mi < fMi; mi++) {
+    const meso = originalPlan.mesocycles[mi]!;
+    outputMesos.push({
+      ...meso,
+      fractals: meso.fractals.map((f) => ({
+        ...f,
+        weeks: f.weeks.map((w) => ({ ...w })),
+      })),
+    });
+  }
+
+  // Collect frozen fractals from the frontier mesocycle
+  const frontierMeso = originalPlan.mesocycles[fMi]!;
+  const frozenFractals: Plan["mesocycles"][number]["fractals"] = [];
+
+  // Fractals entirely before the frontier fractal
+  for (let fi = 0; fi < fFi; fi++) {
+    frozenFractals.push({
+      weeks: frontierMeso.fractals[fi]!.weeks.map((w) => ({ ...w })),
+    });
+  }
+
+  // Frozen portion of the frontier fractal (if frontier is mid-fractal)
+  if (fWi > 0) {
+    frozenFractals.push({
+      weeks: frontierMeso.fractals[fFi]!.weeks.slice(0, fWi).map((w) => ({ ...w })),
+    });
+  }
+
+  // Attach the frontier mesocycle and all future mesocycles.
+  // The future plan's mesocycles[0] corresponds to the frontier mesocycle
+  // (same name), unless all its fractals were dropped by the strategy.
+  const futureMesos = futurePlan.mesocycles;
+
+  if (futureMesos.length > 0 && futureMesos[0]!.name === frontierMeso.name) {
+    // The future plan continues the frontier mesocycle
+    const futureFractalsFromFrontierMeso = futureMesos[0]!.fractals;
+
+    let combinedFractals: Plan["mesocycles"][number]["fractals"];
+
+    if (fWi > 0 && frozenFractals.length > 0 && futureFractalsFromFrontierMeso.length > 0) {
+      // Last frozen fractal and first future fractal are both parts of the
+      // same original fractal — merge their weeks into a single fractal.
+      const mergedBoundaryFractal = {
+        weeks: [
+          ...frozenFractals[frozenFractals.length - 1]!.weeks,
+          ...futureFractalsFromFrontierMeso[0]!.weeks,
+        ],
+      };
+      combinedFractals = [
+        ...frozenFractals.slice(0, -1),
+        mergedBoundaryFractal,
+        ...futureFractalsFromFrontierMeso.slice(1),
+      ];
+    } else {
+      combinedFractals = [...frozenFractals, ...futureFractalsFromFrontierMeso];
+    }
+
+    outputMesos.push({ name: frontierMeso.name, fractals: combinedFractals });
+
+    for (let i = 1; i < futureMesos.length; i++) {
+      outputMesos.push(futureMesos[i]!);
+    }
+  } else {
+    // The future plan starts with a different mesocycle (all fractals of
+    // the frontier mesocycle were dropped by the strategy, or the frontier
+    // is at a clean mesocycle boundary).
+    if (frozenFractals.length > 0) {
+      outputMesos.push({ name: frontierMeso.name, fractals: frozenFractals });
+    }
+    for (const futureMeso of futureMesos) {
+      outputMesos.push(futureMeso);
+    }
+  }
+
+  return {
+    ...originalPlan,
+    ...(newRaceDate !== undefined ? { raceDate: newRaceDate } : {}),
+    mesocycles: outputMesos,
+  };
+}
+
+/**
+ * Applies notes from the original future weeks to the merged plan.
+ * Notes are matched by position in the flat future week list and
+ * preserved only when the planned type is unchanged at that position.
+ *
+ * This is non-destructive: notes are only applied when the week structure
+ * is unchanged (same planned type at the same relative position).
+ */
+function preserveFutureNotes(
+  mergedPlan: Plan,
+  originalFlatWeeks: FlatWeek[],
+  frontierIdx: number,
+): Plan {
+  // Collect (relativeIdx, planned, note) from original future weeks
+  const originalFutureNotes: Array<{ relPos: number; planned: string; note: string }> = [];
+  for (let i = frontierIdx; i < originalFlatWeeks.length; i++) {
+    const fw = originalFlatWeeks[i]!;
+    if (fw.note !== undefined) {
+      originalFutureNotes.push({
+        relPos: i - frontierIdx,
+        planned: fw.planned,
+        note: fw.note,
+      });
+    }
+  }
+
+  if (originalFutureNotes.length === 0) return mergedPlan;
+
+  // Flatten future weeks in merged plan
+  // Count frozen weeks (those with executed) — the future weeks come after
+  const mergedFlat = mergedPlan.mesocycles.flatMap((m) =>
+    m.fractals.flatMap((f) => f.weeks),
+  );
+
+  const frozenCount = mergedFlat.filter((w) => w.executed !== undefined).length;
+
+  // Apply notes where planned type matches at same relative position
+  const result = clonePlan(mergedPlan);
+  const resultFlat = result.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks));
+
+  for (const { relPos, planned, note } of originalFutureNotes) {
+    const targetIdx = frozenCount + relPos;
+    const targetWeek = resultFlat[targetIdx];
+    if (targetWeek && targetWeek.planned === planned && targetWeek.executed === undefined) {
+      targetWeek.note = note;
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Core function
+// ---------------------------------------------------------------------------
+
+/**
+ * Adjusts the future (unexecuted) portion of a training plan.
+ *
+ * - `strategy`: applies a named compression strategy to future weeks
+ * - `raceDate`: re-reconciles future weeks against a new race date
+ * - neither: returns an informational view of the current future structure
+ *
+ * Executed weeks are frozen and never modified.
+ *
+ * @throws AdjustError when no future weeks exist or strategy is impossible
+ */
+export function adjustPlan(plan: Plan, options: AdjustOptions): AdjustResult {
+  const flat = flattenWeeks(plan);
+
+  // Find the frontier: first week without executed
+  const frontierIdx = flat.findIndex((w) => w.executed === undefined);
+
+  if (frontierIdx === -1) {
+    throw new AdjustError(
+      "all weeks are already executed; nothing to adjust",
+      "NO_FUTURE_WEEKS",
+    );
+  }
+
+  const futureTemplate = extractFutureTemplate(plan, flat, frontierIdx);
+  const startOfFuture = flat[frontierIdx]!.start;
+  const effectiveRaceDate = options.raceDate ?? plan.raceDate;
+
+  // ── Informational mode ─────────────────────────────────────────────────────
+
+  if (options.strategy === undefined && options.raceDate === undefined) {
+    const frozenWeeks = frontierIdx;
+    const adjustableWeeks = flat.length - frontierIdx;
+
+    let availableStrategies: CompressionOption[] = [];
+
+    if (effectiveRaceDate !== undefined) {
+      const result = reconcile({
+        template: futureTemplate,
+        start: startOfFuture,
+        raceDate: effectiveRaceDate,
+        distance: options.distance ?? plan.distance,
+        weekStart: options.weekStart,
+      });
+      availableStrategies = result.options;
+    }
+
+    return {
+      mode: "info",
+      frozenWeeks,
+      adjustableWeeks,
+      availableStrategies,
+      currentRaceDate: plan.raceDate,
+    };
+  }
+
+  // ── Strategy / race-date mode ──────────────────────────────────────────────
+
+  if (effectiveRaceDate === undefined) {
+    throw new AdjustError(
+      "plan has no race_date; provide --race-date to adjust a bridge block",
+      "NO_RACE_DATE",
+    );
+  }
+
+  const reconcileResult = reconcile({
+    template: futureTemplate,
+    start: startOfFuture,
+    raceDate: effectiveRaceDate,
+    distance: options.distance ?? plan.distance,
+    weekStart: options.weekStart,
+    strategy: options.strategy,
+  });
+
+  if (reconcileResult.plan === null) {
+    throw new AdjustError(
+      options.strategy !== undefined
+        ? `strategy "${options.strategy}" cannot be applied to the current future weeks`
+        : "future weeks do not fit the new race date; provide --strategy to compress",
+      "STRATEGY_IMPOSSIBLE",
+    );
+  }
+
+  // Merge frozen history + reconciled future weeks
+  const merged = mergeFrozenAndFuture(
+    plan,
+    flat,
+    frontierIdx,
+    reconcileResult.plan,
+    options.raceDate, // only update raceDate when explicitly changed
+  );
+
+  // Preserve notes from original future weeks where structure is unchanged
+  const withNotes = preserveFutureNotes(merged, flat, frontierIdx);
+
+  return { mode: "plan", plan: withNotes };
+}


### PR DESCRIPTION
Restructures future weeks of an existing plan when circumstances change — race date moved, schedule compressed, or strategy shift needed.

Reuses the reconciliation module from PR #13 .

Resolves #16