### PR TITLE
Adds quantify integration and run association

### DIFF
--- a/packages/cli/src/commands/quantify.ts
+++ b/packages/cli/src/commands/quantify.ts
@@ -1,12 +1,14 @@
 import { defineCommand } from "citty";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import {
   loadConfig,
+  loadPlan,
   quantify,
   formatResult,
   DEFAULT_PROFILE,
 } from "@run2max/engine";
-import type { OutputFormat, OutputProfileConfig } from "@run2max/engine";
+import type { OutputFormat, OutputProfileConfig, Plan } from "@run2max/engine";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,6 +101,11 @@ export default defineCommand({
       default: false,
       description: "Skip weather fetch even if config has weather enabled",
     },
+    plan: {
+      type: "string",
+      description:
+        "Path to plan.yaml or directory containing plan.yaml. Auto-discovered from the .fit file's directory when absent.",
+    },
   },
 
   async run({ args }) {
@@ -189,6 +196,34 @@ export default defineCommand({
     // ---- Resolve timezone
     const timezone = args.timezone ?? config?.athlete?.timezone;
 
+    // ---- Discover and load plan.yaml (silent when absent)
+    const fitDir = resolve(dirname(args.file));
+    let plan: Plan | undefined;
+    if (args.plan) {
+      // --plan can be a file path or a directory path
+      const planArg = resolve(args.plan);
+      let planPath: string;
+      try {
+        const s = await stat(planArg);
+        planPath = s.isDirectory() ? join(planArg, "plan.yaml") : planArg;
+      } catch {
+        fatal(`Cannot access --plan path "${args.plan}"`);
+      }
+      try {
+        plan = await loadPlan(planPath!);
+      } catch (err) {
+        fatal(`Could not load plan: ${(err as Error).message}`);
+      }
+    } else {
+      // Auto-discover plan.yaml in the same directory as the .fit file
+      const autoPlanPath = join(fitDir, "plan.yaml");
+      try {
+        plan = await loadPlan(autoPlanPath);
+      } catch {
+        // Silent — no plan.yaml present
+      }
+    }
+
     // ---- Run analysis
     let result;
     try {
@@ -202,6 +237,8 @@ export default defineCommand({
         downsample,
         excludeAnomalies: args["exclude-anomalies"],
         noWeather: args["no-weather"],
+        plan,
+        fitDirPath: fitDir,
       });
     } catch (err) {
       fatal(

--- a/packages/engine/src/computations/quantify.ts
+++ b/packages/engine/src/computations/quantify.ts
@@ -5,6 +5,7 @@ import {
 } from "normalize-fit-file";
 import type {
   AnalysisResult,
+  PlanContext,
   QuantifyOptions,
   Run2MaxRecord,
   WeatherSummary,
@@ -13,6 +14,7 @@ import type {
   KmSplitRow,
 } from "../types.js";
 import { ENGINE_VERSION } from "../index.js";
+import { associateRun, scanBlockRuns } from "../plan/associate.js";
 import { detectCapabilities } from "../detect-capabilities.js";
 import { detectAnomalies, applyAnomalyExclusions } from "./anomalies.js";
 import { computeSummary } from "./summary.js";
@@ -136,6 +138,60 @@ export async function quantify(
     }
   }
 
+  // 9. Plan context (optional — only when options.plan is provided)
+  let planContext: PlanContext | undefined;
+  if (options.plan) {
+    const timezone = options.timezone ?? config?.athlete?.timezone ?? "UTC";
+    const weekAssoc = associateRun(options.plan, summary.date, timezone);
+
+    if (weekAssoc) {
+      // Compute week progress when microcycle config and fitDirPath are available
+      let weekProgress: PlanContext["weekProgress"];
+      const microcycle = config?.microcycle;
+      const fitDir = options.fitDirPath ?? ".";
+
+      if (microcycle?.default) {
+        const nonRestDays = Object.values(microcycle.default).filter(
+          (dayType) => dayType !== "rest",
+        ).length;
+
+        const blockRuns = await scanBlockRuns(fitDir);
+        const runsInWeek = blockRuns.filter((r) => {
+          const localDate = new Intl.DateTimeFormat("en-CA", {
+            timeZone: timezone,
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          }).format(r.date);
+          const weekEnd = (() => {
+            const d = new Date(weekAssoc.weekStart + "T00:00:00Z");
+            d.setUTCDate(d.getUTCDate() + 7);
+            return d.toISOString().slice(0, 10);
+          })();
+          return localDate >= weekAssoc.weekStart && localDate < weekEnd;
+        });
+
+        weekProgress = {
+          completed: runsInWeek.length,
+          expected: nonRestDays,
+          runs: runsInWeek.map((r) => r.displayName),
+        };
+      }
+
+      planContext = {
+        block: options.plan.block,
+        goal: options.plan.goal,
+        weekNumber: weekAssoc.weekNumber,
+        totalWeeks: weekAssoc.totalWeeks,
+        weekType: weekAssoc.weekType,
+        mesocycle: weekAssoc.mesocycle,
+        fractalIndex: weekAssoc.fractalIndex,
+        totalFractals: weekAssoc.totalFractals,
+        weekProgress,
+      };
+    }
+  }
+
   return {
     metadata: {
       version: ENGINE_VERSION,
@@ -155,5 +211,6 @@ export async function quantify(
     weatherPerSplit,
     anomalies,
     capabilities,
+    planContext,
   };
 }

--- a/packages/engine/src/formatters/index.ts
+++ b/packages/engine/src/formatters/index.ts
@@ -6,6 +6,7 @@ import type {
   ElevationProfile,
   FormatResult,
   OutputFormat,
+  PlanContext,
   RunSummary,
   SegmentRow,
   KmSplitRow,
@@ -56,6 +57,8 @@ interface FilteredResult {
   weatherSummary?: WeatherSummary | null;
   weatherPerSplit?: WeatherPerSplit[];
   anomalies?: Anomaly[];
+  /** Periodization context — always passed through when present on AnalysisResult. */
+  planContext?: PlanContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +128,8 @@ function applyProfile(
   const filtered: FilteredResult = {
     metadata: result.metadata,
     capabilities: result.capabilities,
+    // planContext is always forwarded — not gated by any profile section
+    planContext: result.planContext,
   };
 
   if (activeSections.includes("summary"))           filtered.summary = result.summary;

--- a/packages/engine/src/formatters/json.ts
+++ b/packages/engine/src/formatters/json.ts
@@ -1,10 +1,12 @@
-import type { AnalysisResult, ColumnId, SegmentRow, KmSplitRow } from "../types.js";
+import type { AnalysisResult, ColumnId, PlanContext, SegmentRow, KmSplitRow } from "../types.js";
 import { COLUMN_FIELD_MAP } from "./utils.js";
 
 type FilteredResult = Pick<
   AnalysisResult,
   "metadata" | "capabilities"
-> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">>;
+> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">> & {
+  planContext?: PlanContext;
+};
 
 const SEGMENT_IDENTITY = ["lapIndex", "distance", "duration"] as const;
 const KM_IDENTITY = ["km", "distance", "duration"] as const;
@@ -51,6 +53,7 @@ export function formatJson(
   if (filtered.paceZoneDistribution !== undefined) out["paceZoneDistribution"] = filtered.paceZoneDistribution;
   if (filtered.dynamicsSummary !== undefined)  out["dynamicsSummary"] = filtered.dynamicsSummary;
   if (filtered.anomalies !== undefined)        out["anomalies"] = filtered.anomalies;
+  if (filtered.planContext !== undefined)      out["planContext"] = filtered.planContext;
 
   return JSON.stringify(out, null, 2);
 }

--- a/packages/engine/src/formatters/markdown.ts
+++ b/packages/engine/src/formatters/markdown.ts
@@ -1,6 +1,7 @@
 import type {
   AnalysisResult,
   ColumnId,
+  PlanContext,
   SectionId,
 } from "../types.js";
 import type { OutputProfileConfig } from "../config/schema.js";
@@ -41,7 +42,9 @@ import { renderElevationChart } from "./ascii-chart.js";
 type FilteredResult = Pick<
   AnalysisResult,
   "metadata" | "capabilities"
-> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">>;
+> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">> & {
+  planContext?: PlanContext;
+};
 
 // ---------------------------------------------------------------------------
 // Section renderers
@@ -318,6 +321,29 @@ function renderAnomalies(result: FilteredResult): string {
 }
 
 // ---------------------------------------------------------------------------
+// Plan context header (always rendered above sections when present)
+// ---------------------------------------------------------------------------
+
+function renderPlanContext(ctx: PlanContext): string {
+  // Example: BUILD — Week 7/18 (LLL) | CANAL, Fractal 2 | Half Marathon Santiago
+  const parts: string[] = [
+    `${ctx.block.toUpperCase()} — Week ${ctx.weekNumber}/${ctx.totalWeeks} (${ctx.weekType})`,
+    `${ctx.mesocycle}, Fractal ${ctx.fractalIndex}`,
+  ];
+  if (ctx.goal) parts.push(ctx.goal);
+
+  const header = parts.join(" | ");
+
+  if (!ctx.weekProgress) return header;
+
+  const { completed, expected, runs } = ctx.weekProgress;
+  const runList = runs.length > 0 ? ` (${runs.join(", ")})` : "";
+  const progressLine = `  Week progress: run ${completed}/${expected}${runList}`;
+
+  return [header, progressLine].join("\n");
+}
+
+// ---------------------------------------------------------------------------
 // Section dispatch
 // ---------------------------------------------------------------------------
 
@@ -348,6 +374,11 @@ export function formatMarkdown(
   activeColumns: ColumnId[],
 ): string {
   const parts: string[] = [];
+
+  // Plan context header block is always shown when present — not profile-gated.
+  if (filtered.planContext) {
+    parts.push(renderPlanContext(filtered.planContext));
+  }
 
   for (const section of activeSections) {
     const rendered = SECTION_RENDERERS[section](filtered, activeColumns);

--- a/packages/engine/src/formatters/yaml.ts
+++ b/packages/engine/src/formatters/yaml.ts
@@ -1,11 +1,13 @@
 import { stringify } from "yaml";
-import type { AnalysisResult, ColumnId, SegmentRow, KmSplitRow } from "../types.js";
+import type { AnalysisResult, ColumnId, PlanContext, SegmentRow, KmSplitRow } from "../types.js";
 import { COLUMN_FIELD_MAP, camelToSnake } from "./utils.js";
 
 type FilteredResult = Pick<
   AnalysisResult,
   "metadata" | "capabilities"
-> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">>;
+> & Partial<Omit<AnalysisResult, "metadata" | "capabilities">> & {
+  planContext?: PlanContext;
+};
 
 const SEGMENT_IDENTITY = ["lapIndex", "distance", "duration"] as const;
 const KM_IDENTITY = ["km", "distance", "duration"] as const;
@@ -52,6 +54,7 @@ export function formatYaml(
   if (filtered.paceZoneDistribution !== undefined) out["paceZoneDistribution"] = filtered.paceZoneDistribution;
   if (filtered.dynamicsSummary !== undefined)  out["dynamicsSummary"] = filtered.dynamicsSummary;
   if (filtered.anomalies !== undefined)        out["anomalies"] = filtered.anomalies;
+  if (filtered.planContext !== undefined)      out["planContext"] = filtered.planContext;
 
   return stringify(camelToSnake(out));
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ElevationProfile,
   WeatherSummary,
   WeatherPerSplit,
+  PlanContext,
 } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -82,6 +83,8 @@ export { syncWeek, SyncError } from "./plan/sync.js";
 export type { SyncData } from "./plan/sync.js";
 export { adjustPlan, AdjustError } from "./plan/adjust.js";
 export type { AdjustOptions, AdjustResult } from "./plan/adjust.js";
+export { associateRun, scanBlockRuns, extractDisplayName } from "./plan/associate.js";
+export type { WeekAssociation, BlockRun } from "./plan/associate.js";
 
 // ---------------------------------------------------------------------------
 // Plan templates

--- a/packages/engine/src/plan/associate.test.ts
+++ b/packages/engine/src/plan/associate.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parsePlan } from "./schema.js";
+import { associateRun, scanBlockRuns, extractDisplayName } from "./associate.js";
+
+// ---------------------------------------------------------------------------
+// Shared test fixture
+// ---------------------------------------------------------------------------
+
+/**
+ * 10-week plan spanning two mesocycles.
+ *
+ * CANAL / F1: L(1)  LL(2)  LLL(3)  D(4)  Ta(5)  Tb(6)  — 2026-05-04 to 2026-06-20
+ * CANAL / F2: L(7)  LL(8)  LLL(9)                       — 2026-06-15 to 2026-07-05
+ * TAPER / F1: P(10)                                       — 2026-07-06 to 2026-07-12
+ *
+ * Note: weeks in CANAL/F2 immediately follow F1 (no gap).
+ */
+function makePlan() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Santiago",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              { planned: "L",   start: "2026-05-04" },
+              { planned: "LL",  start: "2026-05-11" },
+              { planned: "LLL", start: "2026-05-18" },
+              { planned: "D",   start: "2026-05-25" },
+              { planned: "Ta",  start: "2026-06-01" },
+              { planned: "Tb",  start: "2026-06-08" },
+            ],
+          },
+          {
+            weeks: [
+              { planned: "L",   start: "2026-06-15" },
+              { planned: "LL",  start: "2026-06-22" },
+              { planned: "LLL", start: "2026-06-29" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "TAPER",
+        fractals: [
+          {
+            weeks: [
+              { planned: "P", start: "2026-07-06" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// associateRun
+// ---------------------------------------------------------------------------
+
+describe("associateRun", () => {
+  it("matches activity date to correct week — happy path", () => {
+    const plan = makePlan();
+    // 2026-06-20 falls in CANAL/F2 week 7 (L, 2026-06-15 to 2026-06-21)
+    const result = associateRun(plan, new Date("2026-06-20T12:00:00Z"), "UTC");
+
+    expect(result).not.toBeNull();
+    expect(result!.weekNumber).toBe(7);
+    expect(result!.totalWeeks).toBe(10);
+    expect(result!.weekType).toBe("L");
+    expect(result!.mesocycle).toBe("CANAL");
+    expect(result!.fractalIndex).toBe(2);
+    expect(result!.totalFractals).toBe(2);
+  });
+
+  it("returns null when date is before plan start — outside range", () => {
+    const plan = makePlan();
+    // 2026-05-03 is the day before the first week starts (2026-05-04)
+    const result = associateRun(plan, new Date("2026-05-03T12:00:00Z"), "UTC");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when date is after last week — outside range", () => {
+    const plan = makePlan();
+    // 2026-07-13 is after last week ends (2026-07-06 + 7 = 2026-07-13, exclusive)
+    const result = associateRun(plan, new Date("2026-07-13T12:00:00Z"), "UTC");
+    expect(result).toBeNull();
+  });
+
+  it("uses timezone for date conversion — timezone handling", () => {
+    const plan = makePlan();
+
+    // 2026-05-04T02:00:00Z = May 4 at 2 AM UTC
+    // In America/Santiago (UTC-4 in May), that is still May 3 at 10 PM local
+    // so with Santiago timezone the date is "2026-05-03" → before plan → null
+    const utcDate = new Date("2026-05-04T02:00:00Z");
+
+    const withSantiago = associateRun(plan, utcDate, "America/Santiago");
+    expect(withSantiago).toBeNull(); // local date is May 3, before plan start
+
+    const withUtc = associateRun(plan, utcDate, "UTC");
+    expect(withUtc).not.toBeNull(); // local date is May 4, week 1
+    expect(withUtc!.weekNumber).toBe(1);
+  });
+
+  it("handles week boundary correctly — first day of week", () => {
+    const plan = makePlan();
+    // 2026-05-11 is exactly the start of week 2 (LL)
+    const result = associateRun(plan, new Date("2026-05-11T00:00:00Z"), "UTC");
+
+    expect(result).not.toBeNull();
+    expect(result!.weekNumber).toBe(2);
+    expect(result!.weekType).toBe("LL");
+  });
+
+  it("handles week boundary correctly — last day of week", () => {
+    const plan = makePlan();
+    // 2026-05-10 is the last day of week 1 (L, starts 2026-05-04, ends before 2026-05-11)
+    const result = associateRun(plan, new Date("2026-05-10T23:59:59Z"), "UTC");
+
+    expect(result).not.toBeNull();
+    expect(result!.weekNumber).toBe(1);
+    expect(result!.weekType).toBe("L");
+  });
+
+  it("returns correct fractal and mesocycle for TAPER week", () => {
+    const plan = makePlan();
+    // 2026-07-08 falls in TAPER/F1 (week 10, P)
+    const result = associateRun(plan, new Date("2026-07-08T12:00:00Z"), "UTC");
+
+    expect(result).not.toBeNull();
+    expect(result!.weekNumber).toBe(10);
+    expect(result!.weekType).toBe("P");
+    expect(result!.mesocycle).toBe("TAPER");
+    expect(result!.fractalIndex).toBe(1);
+    expect(result!.totalFractals).toBe(1);
+  });
+
+  it("exposes weekStart for downstream week progress filtering", () => {
+    const plan = makePlan();
+    const result = associateRun(plan, new Date("2026-06-20T12:00:00Z"), "UTC");
+
+    expect(result).not.toBeNull();
+    expect(result!.weekStart).toBe("2026-06-15");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDisplayName
+// ---------------------------------------------------------------------------
+
+describe("extractDisplayName", () => {
+  it("uses block-number pattern when matched — pattern extraction", () => {
+    expect(extractDisplayName("build-10.fit")).toBe("build-10");
+    expect(extractDisplayName("run-1.fit")).toBe("run-1");
+    expect(extractDisplayName("canal-42.fit")).toBe("canal-42");
+  });
+
+  it("uses raw name when pattern not matched — fallback", () => {
+    expect(extractDisplayName("track tuesday.fit")).toBe("track tuesday");
+    expect(extractDisplayName("morning run.fit")).toBe("morning run");
+    expect(extractDisplayName("my-workout.fit")).toBe("my-workout");
+  });
+
+  it("is case-insensitive for the .fit extension", () => {
+    expect(extractDisplayName("build-10.FIT")).toBe("build-10");
+    expect(extractDisplayName("track tuesday.Fit")).toBe("track tuesday");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanBlockRuns
+// ---------------------------------------------------------------------------
+
+describe("scanBlockRuns", () => {
+  it("returns empty array for directory with no .fit files — graceful", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "r2m-test-"));
+    try {
+      // Write a non-.fit file to ensure filtering works
+      await writeFile(join(dir, "notes.txt"), "not a fit file");
+      const result = await scanBlockRuns(dir);
+      expect(result).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty array for nonexistent directory — graceful", async () => {
+    const result = await scanBlockRuns("/does/not/exist/at/all");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for empty directory — graceful", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "r2m-test-"));
+    try {
+      const result = await scanBlockRuns(dir);
+      expect(result).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/engine/src/plan/associate.ts
+++ b/packages/engine/src/plan/associate.ts
@@ -1,0 +1,188 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parseFitBuffer, normalizeFFP } from "normalize-fit-file";
+import type { Plan } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WeekAssociation {
+  weekNumber: number;
+  totalWeeks: number;
+  weekType: string;
+  mesocycle: string;
+  fractalIndex: number;
+  totalFractals: number;
+  /** ISO date of the week's Monday (or configured week start). */
+  weekStart: string;
+}
+
+export interface BlockRun {
+  path: string;
+  displayName: string;
+  date: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers
+// ---------------------------------------------------------------------------
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Converts a UTC Date to a local ISO date string (YYYY-MM-DD) in the given
+ * timezone. Uses the "en-CA" locale which produces ISO 8601 date format.
+ */
+function toLocalDate(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+// ---------------------------------------------------------------------------
+// extractDisplayName
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the display name for a .fit file: strips the `.fit` extension.
+ * Both `build-10.fit` → `build-10` and `track tuesday.fit` → `track tuesday`.
+ */
+export function extractDisplayName(fileName: string): string {
+  return fileName.replace(/\.fit$/i, "");
+}
+
+// ---------------------------------------------------------------------------
+// associateRun
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds the week in the plan that contains the given activity date.
+ *
+ * The activityDate is converted to a local date string using the supplied
+ * timezone before comparison. Returns null when the date falls outside every
+ * week range in the plan.
+ */
+export function associateRun(
+  plan: Plan,
+  activityDate: Date,
+  timezone: string,
+): WeekAssociation | null {
+  const localDate = toLocalDate(activityDate, timezone);
+
+  // Flatten all weeks from every mesocycle/fractal with structural metadata.
+  const flatWeeks: Array<{
+    weekNumber: number;
+    weekType: string;
+    mesocycle: string;
+    fractalIndex: number;
+    totalFractals: number;
+    weekStart: string;
+  }> = [];
+
+  let idx = 1;
+  for (const meso of plan.mesocycles) {
+    const totalFractals = meso.fractals.length;
+    let fi = 1;
+    for (const fractal of meso.fractals) {
+      for (const week of fractal.weeks) {
+        flatWeeks.push({
+          weekNumber: idx++,
+          weekType: week.planned,
+          mesocycle: meso.name,
+          fractalIndex: fi,
+          totalFractals,
+          weekStart: week.start,
+        });
+      }
+      fi++;
+    }
+  }
+
+  const totalWeeks = flatWeeks.length;
+
+  for (const w of flatWeeks) {
+    const weekEnd = addDays(w.weekStart, 7);
+    if (localDate >= w.weekStart && localDate < weekEnd) {
+      return {
+        weekNumber: w.weekNumber,
+        totalWeeks,
+        weekType: w.weekType,
+        mesocycle: w.mesocycle,
+        fractalIndex: w.fractalIndex,
+        totalFractals: w.totalFractals,
+        weekStart: w.weekStart,
+      };
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// scanBlockRuns
+// ---------------------------------------------------------------------------
+
+function nodeBufferToArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(
+    buf.byteOffset,
+    buf.byteOffset + buf.byteLength,
+  ) as ArrayBuffer;
+}
+
+/**
+ * Reads all `.fit` files in `dirPath` and returns their activity timestamps
+ * and display names, sorted by date ascending.
+ *
+ * Files that cannot be parsed are silently skipped. Returns an empty array
+ * when the directory does not exist or contains no `.fit` files.
+ *
+ * Note: Uses parseFitBuffer to extract the session timestamp. Only the header
+ * and session record are needed, but the full parse is used for robustness
+ * with the existing normalize-fit-file library.
+ */
+export async function scanBlockRuns(dirPath: string): Promise<BlockRun[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dirPath);
+  } catch {
+    return [];
+  }
+
+  const fitFiles = entries.filter((f) => /\.fit$/i.test(f));
+  const results: BlockRun[] = [];
+
+  for (const fileName of fitFiles) {
+    const filePath = join(dirPath, fileName);
+    try {
+      const buf = await readFile(filePath);
+      const arrayBuf = nodeBufferToArrayBuffer(buf);
+      const rawData = await parseFitBuffer(arrayBuf);
+      const normalized = normalizeFFP(rawData);
+
+      const rawDate =
+        normalized.metadata.startTime ?? normalized.metadata.timestamp;
+      if (!rawDate) continue;
+
+      const date = rawDate instanceof Date ? rawDate : new Date(rawDate);
+
+      results.push({
+        path: filePath,
+        displayName: extractDisplayName(fileName),
+        date,
+      });
+    } catch {
+      // Skip files that cannot be parsed
+    }
+  }
+
+  results.sort((a, b) => a.date.getTime() - b.date.getTime());
+  return results;
+}

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,5 +1,6 @@
 import type { RecordData } from "normalize-fit-file";
 import type { Run2MaxConfig } from "./config/schema.js";
+import type { Plan } from "./plan/schema.js";
 export type { Run2MaxConfig, ZoneConfig, OutputProfileConfig } from "./config/schema.js";
 
 // ---------------------------------------------------------------------------
@@ -60,6 +61,14 @@ export interface QuantifyOptions {
   downsample?: number;
   excludeAnomalies?: boolean;
   noWeather?: boolean;  // CLI --no-weather flag; overrides config.weather
+  /** Parsed plan.yaml for periodization context enrichment. */
+  plan?: Plan;
+  /**
+   * Directory containing .fit files for this training block.
+   * Used to count completed runs in the current week.
+   * Defaults to the current working directory when plan is provided.
+   */
+  fitDirPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -227,6 +236,28 @@ export interface AnalysisResult {
   weatherPerSplit: WeatherPerSplit[];
   anomalies: Anomaly[];
   capabilities: DataCapabilities;
+  /** Periodization context from plan.yaml. Undefined when no plan is present. */
+  planContext?: PlanContext;
+}
+
+// ---------------------------------------------------------------------------
+// Plan context (added to AnalysisResult when a plan.yaml is present)
+// ---------------------------------------------------------------------------
+
+export interface PlanContext {
+  block: string;
+  goal?: string;
+  weekNumber: number;
+  totalWeeks: number;
+  weekType: string;
+  mesocycle: string;
+  fractalIndex: number;
+  totalFractals: number;
+  weekProgress?: {
+    completed: number;
+    expected: number;
+    runs: string[];
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
When a plan.yaml is present, enrich quantify output with periodization context — where this run sits in the training block, mesocycle, fractal, and week. Date-based auto-matching associates .fit files to plan weeks.

Resolves #17 