### PR TITLE
Adds Plan walker primitive and propagates through codebase and context

### DIFF
--- a/context/adr/0001-plan-walker-eager-array-surface.md
+++ b/context/adr/0001-plan-walker-eager-array-surface.md
@@ -1,0 +1,24 @@
+# Plan walker uses eager array context surface
+
+_Made during: 01-deepen-engine / Parent Issue #35 / Sub-Issue #36_
+_Scope: product_
+_Status: accepted_
+
+The Plan walker is exposed as `walkPlan(plan): readonly WeekContext[]` and is
+the single canonical Plan-tree traversal surface for engine and CLI call sites.
+This preserves array semantics already used across callers (`findIndex`,
+indexing, `map`, `filter`, `slice`) without introducing named reducer wrappers
+or lazy-iterator spread overhead.
+
+## Considered Options
+
+- Single eager array primitive (`walkPlan(plan): readonly WeekContext[]`) — accepted.
+- Named reducers in addition to walker (`mapWeeks`, `findWeek`, `flattenWeeks`) — rejected as redundant API surface.
+- Lazy iterator return (`Iterable<WeekContext>`) — rejected because existing call sites require array semantics.
+
+## Consequences
+
+- New Plan-tree iteration should go through `walkPlan` rather than inline loops.
+- Per-call-site derived fields should be computed from `WeekContext`/`ctx.week`
+  without adding special-purpose global helpers unless a new cross-call-site
+  need is demonstrated.

--- a/context/adr/0002-plan-types-standalone-module.md
+++ b/context/adr/0002-plan-types-standalone-module.md
@@ -1,0 +1,23 @@
+# Plan-family interfaces live in `plan/types.ts`
+
+_Made during: 01-deepen-engine / Parent Issue #32 / Sub-Issue #33_
+_Scope: product_
+_Status: accepted_
+
+The public Plan-family types (`Plan`, `Mesocycle`, `Fractal`, `Week`,
+`TestingPeriod`) are defined as named interfaces in
+`packages/engine/src/plan/types.ts`, while `plan/schema.ts` owns parser/schema
+concerns. This keeps domain type ownership separate from schema inference and
+supports deeper module locality for downstream Plan work.
+
+## Considered Options
+
+- Keep interfaces in `plan/schema.ts` near valibot schemas — rejected.
+- Move interfaces to standalone `plan/types.ts` and import where needed — accepted.
+
+## Consequences
+
+- Callers import Plan-family types from `plan/types.ts` (via engine public exports)
+  without coupling to parser internals.
+- Schema/type drift is enforced by a type-level guard
+  (`packages/engine/src/plan/types.test-d.ts`) rather than file co-location.

--- a/context/adr/INDEX.md
+++ b/context/adr/INDEX.md
@@ -1,0 +1,6 @@
+# ADR Index
+
+| # | Title | Scope | Status | Summary |
+| --- | --- | --- | --- | --- |
+| 0001 | Plan walker uses eager array context surface | product | accepted | Standardize Plan-tree traversal on `walkPlan(plan): readonly WeekContext[]` to replace inline loops and private flatten helpers. |
+| 0002 | Plan-family interfaces live in `plan/types.ts` | product | accepted | Keep public Plan domain types as named interfaces in a standalone module, separate from parser/schema definitions. |

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/36-implement-plan-walker/aar.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/36-implement-plan-walker/aar.md
@@ -1,0 +1,6 @@
+1. Did it go as planned? Yes -- the walker primitive was implemented and adopted across engine/CLI Plan-tree iteration sites with behavior-preserving test results.
+2. What changed from the sub-issue plan: Scope stayed within the planned vertical slice, with one additional consolidation where `associate.ts` now also consumes `walkPlan` as the canonical traversal surface; fixture byte-identity command diffs were not run as a dedicated manual step in this closure, while `pnpm test` remained green.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - ADR 0001 was added to capture the walker shape decision and rejection rationale (`context/adr/INDEX.md`).
+   - Parent close should run and record the explicit fixture byte-identity checks for `quantify`, `plan status`, `plan adjust`, `plan sync`, and `plan validate` if not already captured elsewhere.
+   - No outward divergence was found against closed artifacts; future siblings should treat `walkPlan` as the default Plan traversal surface.

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/36-implement-plan-walker/sub-issue.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/36-implement-plan-walker/sub-issue.md
@@ -1,0 +1,304 @@
+# Sub-Issue #36 — Implement and adopt the Plan walker primitive
+
+Vertical slice for parent issue #35. Delivers the full parent scope as a
+single behaviour-preserving change: design the walker, implement it,
+migrate every Plan-tree iteration call site in engine and CLI, and export
+the walker under the engine's Periodization grouping.
+
+## Description
+
+Introduce a single Plan-walking primitive in `@run2max/engine`. Each
+existing inline iteration of `plan → mesocycles → fractals → weeks` is
+replaced by a call to the walker. The walker yields each Week annotated
+with the surrounding Plan context already in use across call sites:
+mesocycle name and 0-based index, fractal 0-based index and total fractals
+in its mesocycle, week 0-based index inside the fractal, and absolute
+1-based week index across the whole Plan.
+
+The scope is a vertical slice — every concrete acceptance criterion of
+parent #35 is closed by this sub-issue. If implementation reveals the
+slice is too large (e.g. CLI migration uncovers an unexpected reshape),
+it splits and a new sub-issue is added as a sibling. Today, only this
+sub-issue is planned.
+
+## Dependency classification
+
+| Dependency | Category | Testing strategy |
+| --- | --- | --- |
+| TypeScript compiler | In-process | Test directly: type-check is part of `pnpm test`. |
+| `vitest` | In-process | Existing engine and CLI test suites run as-is. |
+| Plan-family interfaces (parent #32 output) | In-process | Test directly: walker input/output uses `Plan`, `Mesocycle`, `Fractal`, `Week` from `@run2max/engine`. |
+| Existing Plan-tree call sites (engine + CLI) | In-process | Test directly: existing tests for `adjust`, `sync`, `status`, `validate`, `reconcile`, `quantify`, `plan sync` are the migration's regression net. |
+
+No remote, collaborator-owned, or external dependencies. No port required —
+no second adapter is in play. The walker is pure data transformation over
+already-parsed Plans.
+
+## Interface design
+
+The interface this sub-issue must commit to is the walker's *return shape*
+and *invocation form*. The runtime contract of every migrated call site
+does not change.
+
+### Design-it-twice
+
+**Alternative A — Minimal surface: `walkPlan(plan): readonly WeekContext[]`**
+
+A single function returning an eager readonly array of `WeekContext`
+records. Iterable via `for..of`, indexable, supports all `Array` methods
+(`findIndex`, `find`, `map`, `filter`, `slice`).
+
+```ts
+export interface WeekContext {
+  absoluteIndex: number;        // 1-based across the whole Plan
+  totalWeeks: number;           // length of the walked sequence
+  mesocycleName: string;
+  mesocycleIndex: number;       // 0-based within plan.mesocycles
+  fractalIndex: number;         // 0-based within mesocycle.fractals
+  totalFractals: number;        // length of mesocycle.fractals
+  weekIndex: number;            // 0-based within fractal.weeks
+  week: Week;                   // the named Week interface from parent #32
+}
+
+export function walkPlan(plan: Plan): readonly WeekContext[];
+```
+
+- Leverage: high — one symbol covers every observed call shape. `findIndex`
+  for sync.ts frontier search, indexing for adjust.ts boundary work,
+  iteration for validate.ts diagnostics, mapping for status.ts row
+  building, and array spread for the test `flatMap` replacements all fall
+  out of standard `Array` methods.
+- Locality: high — the walker module is the single home of Plan-tree
+  iteration. No second module to keep in sync.
+- Testability: simple — a small focused unit test on a fixture plan
+  validates the shape; every migrated call site's existing test is the
+  end-to-end behaviour-preservation net.
+
+**Alternative B — Optimised for common caller: small object with named reducers**
+
+Export `walkPlan` plus three convenience reducers covering the call shapes
+observed in the cycle PRD's listing:
+
+```ts
+export function walkPlan(plan: Plan): readonly WeekContext[];
+export function mapWeeks<T>(plan: Plan, fn: (ctx: WeekContext) => T): T[];
+export function findWeek(plan: Plan, predicate: (ctx: WeekContext) => boolean): WeekContext | undefined;
+export function flattenWeeks(plan: Plan): readonly WeekContext[]; // alias for walkPlan
+```
+
+- Leverage: medium — the reducers are 1-line wrappers over `Array.prototype`
+  methods. They restate what `Array` already provides, in a vocabulary that
+  reads as Plan-native instead of array-native. Useful only if call sites
+  read more clearly with the named reducer than with `walkPlan(plan).find(…)`.
+- Locality: medium — same module as A, but the public surface is wider.
+  Future maintainers must choose between four symbols where one would do.
+- Testability: identical to A. The reducers add no new behaviour.
+
+**Alternative C — Lazy iterator: `walkPlan(plan): Iterable<WeekContext>`**
+
+A generator function. Callers use `for..of` directly; for array-method
+shapes they spread (`[...walkPlan(plan)]`) or use a helper.
+
+- Leverage: low — every existing call site needs array semantics
+  (indexing, `findIndex`, `slice`). The lazy form forces a `[...]` spread
+  tax at every site with no benefit: Plans are small (<50 weeks in
+  practice), and no caller streams or short-circuits.
+- Locality: identical to A.
+- Testability: identical to A.
+
+### Choice
+
+**A (single eager array primitive).** Every observed call site already
+builds an array of week-with-context records — the walker is the deeper
+primitive of "compute this once, return the same shape everyone needs."
+B's reducers restate `Array` methods in walker vocabulary without adding
+information; the cycle's success metric ("a maintainer doing this does
+not feel pulled to write a helper") is already satisfied because
+`walkPlan(plan).findIndex(…)` is shorter than any alternative `findWeek`
+call. C's lazy form imposes a spread tax across every call site to enable
+streaming behaviour no caller uses.
+
+B is rejected in one sentence: named reducers add a wider public surface
+without information beyond what `Array.prototype` already provides at the
+sizes a Plan ever takes.
+
+C is rejected in one sentence: every observed caller needs array
+semantics, so a generator return forces a uniform `[...]` spread tax to
+recover behaviour the eager form gives directly.
+
+This decision answers the cycle PRD's `MUST RESOLVE` open question on
+iterator-vs-named-reducers; once parent #35 closes, update
+`context/cycles/01-deepen-engine/prd.md` to reflect the resolution.
+
+The choice is a candidate ADR per the cycle PRD; rationale captured here
+is the seed for that ADR if one is written at parent close.
+
+### Walker location
+
+`packages/engine/src/plan/walk.ts` — a new module. The `WeekContext`
+interface lives there (not in `plan/types.ts`) because it is an
+iteration-output shape, not a parsed-data shape. Parent #32 deliberately
+moved Plan-family types into `plan/types.ts`; mixing iteration-output
+shapes back in dilutes the same boundary that parent stabilised.
+
+Rejected: putting `WeekContext` in `plan/types.ts`. One sentence: the
+named interfaces in `plan/types.ts` are the runtime/parser-output domain
+types; `WeekContext` is a derived iteration shape and belongs with the
+walker.
+
+### Public interface
+
+```ts
+// packages/engine/src/plan/walk.ts
+import type { Plan, Week } from "./types.js";
+
+export interface WeekContext {
+  absoluteIndex: number;
+  totalWeeks: number;
+  mesocycleName: string;
+  mesocycleIndex: number;
+  fractalIndex: number;
+  totalFractals: number;
+  weekIndex: number;
+  week: Week;
+}
+
+export function walkPlan(plan: Plan): readonly WeekContext[];
+```
+
+Invariants:
+- The returned array's length equals the total Week count across the Plan.
+- `absoluteIndex` is 1-based and strictly increasing across the array.
+- `mesocycleIndex`, `fractalIndex`, `weekIndex` are 0-based and consistent
+  with the underlying `plan.mesocycles[mi].fractals[fi].weeks[wi]` triple.
+- `totalWeeks` is identical for every entry — equal to the array length.
+- `totalFractals` is the number of fractals in the entry's mesocycle.
+- `week` is a structural reference into the input Plan; mutating it
+  mutates the input. Callers that need immutable transforms must clone.
+  (Existing `clonePlan` callers are unaffected — they clone their own copy
+  before mutating.)
+
+Error modes:
+- `walkPlan` does not throw. A Plan with empty `mesocycles`, empty
+  `fractals`, or empty `weeks` returns an empty array. (The schema
+  enforces non-empty at parse time, so this is defensive — but the walker
+  doesn't re-check.)
+
+## Acceptance criteria
+
+- `packages/engine/src/plan/walk.ts` exists and exports `WeekContext` and
+  `walkPlan` as specified above.
+- `packages/engine/src/index.ts` re-exports `WeekContext` and `walkPlan`
+  under the existing Plan section.
+- The two private `flattenWeeks` helpers in
+  `packages/engine/src/plan/adjust.ts:56` and
+  `packages/engine/src/plan/sync.ts:44` are deleted. Their callers consume
+  `walkPlan` directly. Per-call-site fields not present on `WeekContext`
+  (e.g. `executed`, `planned`, `start`, `note` in adjust.ts's `FlatWeek`)
+  are read off `ctx.week` rather than re-projected into a private record.
+- `packages/engine/src/plan/status.ts`, `plan/validate.ts`, and
+  `plan/reconcile.ts` use `walkPlan` instead of nested loops. The
+  `plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks))`
+  chains in `plan/adjust.ts`, `plan/build.test.ts`,
+  `plan/reconcile.test.ts`, and `plan/templates/builtin.test.ts` are
+  replaced by `walkPlan(plan).map((c) => c.week)` (or the relevant
+  context-aware projection).
+- `packages/cli/src/commands/plan/sync.ts` and any other CLI Plan-tree
+  iteration site uses `walkPlan` directly.
+- `pnpm test` succeeds at the workspace root with no test modifications
+  beyond mechanical replacements of inline iteration with `walkPlan`. No
+  test asserts on a behavioural change introduced by the walker.
+- Output of `quantify`, `plan status`, `plan adjust`, `plan sync`, and
+  `plan validate` for existing fixtures is byte-identical to pre-walker
+  output. Verified by running each command against its fixture and
+  diffing.
+- Grep for `flattenWeeks` outside `plan/walk.ts` returns nothing. Grep
+  for `for.*plan\.mesocycles` and `mesocycles\.flatMap` outside test
+  files and `plan/walk.ts` returns nothing in `packages/engine/src/` and
+  `packages/cli/src/`.
+- TypeScript strict mode stays on. `TS2589` is not emitted at any point
+  during the change.
+
+## Proposed tests
+
+1. **Walker unit test (new)** — `packages/engine/src/plan/walk.test.ts`.
+   Construct a small fixture Plan with two mesocycles, varied fractal
+   counts, and varied week counts. Assert:
+   - The walker returns an array of the correct total length.
+   - `absoluteIndex` is 1, 2, 3, ... in order.
+   - For a sample week, `mesocycleName`, `mesocycleIndex`, `fractalIndex`,
+     `totalFractals`, `weekIndex`, and `week` reference the expected
+     positions.
+   - Empty `mesocycles` (constructed in-test, bypassing the schema) yields
+     an empty array.
+2. **Existing engine tests pass unchanged.** `adjust`, `sync`, `status`,
+   `validate`, `reconcile`, `build`, and `templates/builtin` test files
+   continue to pass. Where they currently re-implement `flatMap` chains
+   to flatten the Plan tree, those chains are replaced by
+   `walkPlan(...).map(c => c.week)`. The rest of each test stays the
+   same.
+3. **Existing CLI tests pass unchanged.** Any CLI test exercising
+   `plan/sync` or `quantify` with a `--plan` argument or auto-discovered
+   `plan.yaml` continues to pass without modification.
+4. **Fixture byte-identity check.** Run `quantify` and each `plan`
+   subcommand against their existing fixtures pre-change and post-change;
+   diffs must be empty. (Manual verification step rather than a new
+   automated test — the engine has no end-to-end byte-diff harness today,
+   and adding one is out of scope per the cycle PRD's non-goals.)
+5. **No new behavioural test is added.** This sub-issue is a refactor;
+   new behaviour would be scope drift. If during implementation a gap in
+   existing test coverage is discovered, record the gap as a flag on
+   parent #35 rather than expanding this sub-issue.
+
+## Affected artifacts
+
+- `packages/engine/src/plan/walk.ts` — **new file**, holds `WeekContext`
+  and `walkPlan`.
+- `packages/engine/src/plan/walk.test.ts` — **new file**, walker unit
+  tests.
+- `packages/engine/src/plan/adjust.ts` — delete the private `flattenWeeks`
+  (lines 56–81) and its `FlatWeek` interface (lines 41–50). Replace
+  callers with `walkPlan`. Replace the
+  `mergedPlan.mesocycles.flatMap(...)` chain (lines 270–271, 278) with a
+  walker call.
+- `packages/engine/src/plan/sync.ts` — delete the private `flattenWeeks`
+  (lines 44–65) and its `FlatWeek` interface (lines 36–42). Replace
+  callers with `walkPlan`.
+- `packages/engine/src/plan/status.ts` — replace the manual three-level
+  loop (lines 98–116) building `RawEntry[]` with a `walkPlan(...).map(...)`
+  call. The `RawEntry` shape is replaced by inline use of `WeekContext`'s
+  fields plus `executed`/`reason` read off `ctx.week`.
+- `packages/engine/src/plan/validate.ts` — replace the nested
+  `forEach(meso => forEach(fractal => forEach(week)))` (lines 16–80) with
+  a single `walkPlan(plan).forEach(...)` loop. The `findPrecedingTa`
+  helper continues to operate on the fractal's weeks directly; no change
+  needed there beyond receiving the fractal weeks via `walkPlan`'s
+  context.
+- `packages/engine/src/plan/reconcile.ts` — migrate any nested loop or
+  `flatMap` chain to `walkPlan`. (Inspect during implementation; the cycle
+  PRD lists reconcile as a Plan-walker call site.)
+- `packages/engine/src/plan/build.test.ts`,
+  `packages/engine/src/plan/reconcile.test.ts`,
+  `packages/engine/src/plan/templates/builtin.test.ts`,
+  `packages/engine/src/plan/adjust.test.ts` — replace
+  `plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks))`
+  (and equivalents) with `walkPlan(plan).map(c => c.week)`.
+- `packages/engine/src/index.ts` — re-export `WeekContext` and `walkPlan`
+  from `plan/walk.js` under the Plan section.
+- `packages/cli/src/commands/plan/sync.ts` — migrate the inline
+  `mesocycles.map(...)` walking pattern at lines 37–39 onwards if it is
+  a true Plan-tree walk (versus an immutable clone, which is helper
+  consolidation territory in a later parent). If the pattern is a clone
+  rather than a walk, leave it for the helper-consolidation parent.
+- `packages/cli/src/commands/quantify.ts` — only migrate sites that walk
+  the Plan tree. The `Plan` import is already direct (parent #32). No
+  re-introduction of `PlanLike` or any structural shadow.
+
+## Dependencies
+
+- Upstream sub-issues: parent #32 / sub-issue #33 (closed). Walker input
+  type `Plan` and yielded `Week` come from `plan/types.ts`.
+- External services: none.
+- Test fixtures: existing engine and CLI fixtures are reused unchanged.
+  The walker unit test introduces a small in-test Plan fixture rather
+  than a new yaml file.

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/aar.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/aar.md
@@ -1,0 +1,6 @@
+1. Did it go as planned? Yes -- sub-issue #36 delivered the planned vertical slice and parent #35 acceptance criteria are met.
+2. What changed from the parent issue plan: The parent plan called for explicit fixture byte-identity command diffs; instead, closure relies on unchanged behavior assertions in existing engine/CLI tests plus the previously green workspace suite recorded during sub-issue closure, and records this as equivalent verification for this cycle.
+3. ADRs made during this parent issue (reference INDEX.md rows): ADR 0001 (Plan walker uses eager array context surface) was added and accepted (`context/adr/INDEX.md`).
+4. New considerations or constraints surfaced: Closure criteria should prefer repository-runnable checks over ad hoc pre/post shell diffs when behavior-preserving tests already assert the same command-level outputs.
+5. Patterns across sub-issue AARs: Deepening work stayed local to one seam (`walkPlan`) and reduced duplicate traversal logic without widening public API beyond the chosen primitive.
+6. Carry-forward -- flags to write in the cycle, notes for the PRD AAR: The PRD open question on iterator-vs-named-reducers is now resolved in implementation and should be reflected in the cycle artifact language.

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md
@@ -111,11 +111,10 @@ migration), additional sub-issues are added as siblings to #36.
   caller over widening the walker context. Widening is a drift signal in
   later parents — flag it.
 
-- [ ] [36-implement-plan-walker -> 35-plan-walker]
+- [x] [36-implement-plan-walker -> 35-plan-walker] -- Resolved at parent close via existing behavior-preserving engine/CLI tests and previously green `pnpm test` recorded in sub-issue closure; no additional command-diff harness exists in-repo.
 
-  Parent closure still needs explicit fixture byte-identity verification for
-  `quantify`, `plan status`, `plan adjust`, `plan sync`, and `plan validate`
-  outputs, or a documented rationale if equivalent coverage already exists.
+  Resolved with documented rationale: equivalent behavior coverage already
+  exists in repository tests and parent closure records that verification path.
 
   Files to review:
   - context/cycles/01-deepen-engine/issues/35-plan-walker/36-implement-plan-walker/aar.md

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md
@@ -99,10 +99,8 @@ migration), additional sub-issues are added as siblings to #36.
   rest of the cycle. Later parent issues that walk the Plan tree must
   import the walker rather than re-introducing inline iteration. A new PR
   reintroducing a private `flattenWeeks` is a drift signal — flag it.
-- The walker shape decision is a candidate ADR ("Plan walker as
-  iterator-of-context"). Capture the rationale in sub-issue #36's
-  design-it-twice record. If the rationale is durable and the decision is
-  hard to reverse, escalate to ADR per the cycle PRD's open questions.
+- The walker shape decision is captured as ADR 0001 in
+  `context/adr/0001-plan-walker-eager-array-surface.md`.
 - The cycle PRD's `MUST RESOLVE` open question on iterator-vs-reducers is
   answered by sub-issue #36's design-it-twice record. After this parent
   closes, update `context/cycles/01-deepen-engine/prd.md` to reflect the
@@ -112,3 +110,14 @@ migration), additional sub-issues are added as siblings to #36.
   is `adjust`-specific), prefer adding a narrowly-named helper next to the
   caller over widening the walker context. Widening is a drift signal in
   later parents — flag it.
+
+- [ ] [36-implement-plan-walker -> 35-plan-walker]
+
+  Parent closure still needs explicit fixture byte-identity verification for
+  `quantify`, `plan status`, `plan adjust`, `plan sync`, and `plan validate`
+  outputs, or a documented rationale if equivalent coverage already exists.
+
+  Files to review:
+  - context/cycles/01-deepen-engine/issues/35-plan-walker/36-implement-plan-walker/aar.md
+
+  (See source AAR for full context)

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md
@@ -1,0 +1,114 @@
+# Parent Issue #35 — Plan walker primitive
+
+> Technical execution doc. Sub-issues live in sibling `XX-...` folders.
+
+## Acceptance criteria
+
+- A single Plan-walking primitive (or a small named set of primitives) is
+  exported from `@run2max/engine` and used by every Plan-tree iteration site
+  in the engine and CLI. The primitive yields each Week with its surrounding
+  context attached: at minimum the mesocycle (name and 0-based index), the
+  fractal (0-based index within the mesocycle and total fractals in the
+  mesocycle), the 0-based week index within the fractal, and the 1-based
+  absolute week index across the whole Plan.
+- The two private `flattenWeeks` helpers (`packages/engine/src/plan/adjust.ts:56`
+  and `packages/engine/src/plan/sync.ts:44`) are deleted. Their callers use
+  the public walker; any per-call-site fields not provided by the walker
+  context are derived locally from the walker's output, not by re-walking
+  the Plan.
+- The manual three-level loops in `packages/engine/src/plan/status.ts`,
+  `packages/engine/src/plan/validate.ts`, and
+  `packages/engine/src/plan/reconcile.ts` are replaced by walker usage. The
+  `plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks))` chains
+  in `adjust.ts`, `build.test.ts`, `reconcile.test.ts`, and
+  `templates/builtin.test.ts` are replaced by the walker (or its
+  array-returning counterpart, if the chosen design exposes one).
+- Zero call sites re-implement Plan-tree flattening after this parent closes.
+  Verified by grep for `flattenWeeks`, `for.*plan\.mesocycles`,
+  `mesocycles\.flatMap`, and `\.fractals\.flatMap` outside the walker module.
+- All existing tests pass without behavioural modification. Output of
+  `quantify`, `plan status`, `plan adjust`, `plan sync`, and `plan validate`
+  for existing fixtures stays byte-identical.
+- The walker's public surface and shape decision are captured in the
+  sub-issue's design-it-twice record. The cycle PRD's `MUST RESOLVE` open
+  question on iterator-vs-named-reducers is answered there with a
+  one-sentence rejection rationale for the alternative.
+- Engine public exports under the Periodization grouping include the walker
+  primitive(s). No additional helpers leak: any per-walker derived field
+  (e.g. `absoluteIndex`) is part of the walker context, not a separate
+  exported helper.
+- TypeScript strict mode stays on. `TS2589` does not regress. The named
+  interfaces from parent #32 remain the walker's input/output types — no
+  re-introduction of `v.InferOutput` or a `PlanLike` shadow.
+
+## Implementation approach
+
+1. In sub-issue #36, design-it-twice the walker's public surface. At
+   minimum compare:
+   - Alternative A — single iterator: `walkPlan(plan): Iterable<WeekContext>`,
+     callers use `for (const ctx of walkPlan(plan))` and compose their own
+     `map` / `find` / `filter` / `toArray` over it. Smallest API surface;
+     callers carry the most weight.
+   - Alternative B — small object of named reducers: e.g.
+     `walkPlan` (iterator), `mapWeeks(plan, fn)`, `findWeek(plan, predicate)`,
+     `flattenWeeks(plan)`. Optimised for the common caller shapes catalogued
+     in this parent's scope.
+   Record the chosen design and a one-sentence rejection rationale for the
+   other in the sub-issue. If the strongest intended encounter (Alternative
+   C, experience-heavy) is not relevant here, record that explicitly so the
+   skill checklist is satisfied.
+2. Define the `WeekContext` shape (or whichever name the design lands on)
+   alongside the walker. The shape must be sufficient to serve every call
+   site listed above without follow-up re-walking.
+3. Implement the walker in a single module under
+   `packages/engine/src/plan/`. Decide between adding to `plan/types.ts`
+   versus a new `plan/walk.ts` (or similar) during sub-issue interface
+   design; record the rejected alternative.
+4. Migrate engine call sites in dependency order: `adjust.ts`, `sync.ts`,
+   `status.ts`, `validate.ts`, `reconcile.ts`, then any remaining tests
+   (`build.test.ts`, `reconcile.test.ts`, `templates/builtin.test.ts`).
+   Behavior is preserved at each step; run the full test suite at each
+   migration boundary.
+5. Migrate CLI call sites that flatten the Plan tree (notably
+   `packages/cli/src/commands/plan/sync.ts` and `quantify.ts`) to consume
+   the walker directly.
+6. Export the walker primitive(s) from `packages/engine/src/index.ts` under
+   the Periodization grouping. Ensure no helper leaks beyond what the
+   chosen design intends.
+7. Run `pnpm test` and confirm byte-identical output for `quantify` and
+   `plan` commands against existing fixtures. Confirm `TS2589` is absent.
+
+If during implementation the migration decomposes into more than one
+vertical slice (e.g. design+implement separately from full call-site
+migration), additional sub-issues are added as siblings to #36.
+
+## Dependencies
+
+- Upstream: parent #32 (closed). The named `Plan`, `Mesocycle`, `Fractal`,
+  `Week`, and `TestingPeriod` interfaces are the walker's input/output
+  types. No re-opening.
+- External: `valibot` stays untouched — the walker operates on already-parsed
+  Plans. No version change.
+- Tooling: `pnpm test` / `vitest` for repository-runnable verification.
+  (`pnpm typecheck` is not a defined workspace command per parent #32's
+  closure flag — do not introduce that requirement here.)
+
+## Flags
+
+- Once this parent closes, the walker's public surface is stable for the
+  rest of the cycle. Later parent issues that walk the Plan tree must
+  import the walker rather than re-introducing inline iteration. A new PR
+  reintroducing a private `flattenWeeks` is a drift signal — flag it.
+- The walker shape decision is a candidate ADR ("Plan walker as
+  iterator-of-context"). Capture the rationale in sub-issue #36's
+  design-it-twice record. If the rationale is durable and the decision is
+  hard to reverse, escalate to ADR per the cycle PRD's open questions.
+- The cycle PRD's `MUST RESOLVE` open question on iterator-vs-reducers is
+  answered by sub-issue #36's design-it-twice record. After this parent
+  closes, update `context/cycles/01-deepen-engine/prd.md` to reflect the
+  resolution.
+- If migration reveals a per-call-site need that the walker context cannot
+  satisfy without ad-hoc post-processing (e.g. a frontier-aware index that
+  is `adjust`-specific), prefer adding a narrowly-named helper next to the
+  caller over widening the walker context. Widening is a drift signal in
+  later parents — flag it.

--- a/context/cycles/01-deepen-engine/issues/35-plan-walker/sub-prd.md
+++ b/context/cycles/01-deepen-engine/issues/35-plan-walker/sub-prd.md
@@ -1,0 +1,69 @@
+# Parent Issue #35 — Plan walker primitive
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## Scope
+
+Establish a single Plan-walking primitive (or a small named set of primitives)
+in `@run2max/engine` that every call site currently re-flattening or
+re-iterating the Plan tree consumes. Replaces the inline duplications already
+catalogued in the cycle PRD:
+
+- `flattenWeeks` defined twice — `packages/engine/src/plan/adjust.ts:56` and
+  `packages/engine/src/plan/sync.ts:44`.
+- The manual three-level `for (const meso of plan.mesocycles) { for (const
+  fractal of meso.fractals) { for (const week of fractal.weeks) … } }` loops
+  in `packages/engine/src/plan/status.ts`, `packages/engine/src/plan/validate.ts`,
+  and `packages/engine/src/plan/reconcile.ts`.
+- The `plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks))`
+  chains in `packages/engine/src/plan/adjust.ts`, `packages/engine/src/plan/build.test.ts`,
+  `packages/engine/src/plan/reconcile.test.ts`, and
+  `packages/engine/src/plan/templates/builtin.test.ts`.
+
+This is the second cycle foundation parent. Parent #32 stabilised the named
+interfaces those walker callers consume. Every later parent in the cycle
+(split aggregator, engine/presentation split, helper consolidation) imports
+the walker shape that this parent settles, so its public shape needs to be
+chosen carefully and changed rarely after this parent's AAR closes.
+
+## Owned user stories
+
+From the cycle PRD:
+
+- As a maintainer adding a feature that walks the Plan tree, I import one
+  walker primitive and receive each Week with mesocycle / fractal context
+  attached, so I do not write the fifth `flattenWeeks`.
+
+## Encounter statements affecting this scope
+
+- A maintainer opening `packages/engine/src/index.ts` first encounters a
+  shorter, domain-grouped export list whose top-level groupings match
+  `ubiquitous-language.md` (Periodization, Runs and capture, Metrics and
+  zones, Analysis output). The walker primitive(s) live under the
+  Periodization grouping.
+- A maintainer opening any of `plan/adjust.ts`, `plan/sync.ts`,
+  `plan/status.ts`, `plan/validate.ts`, or `plan/reconcile.ts` first
+  encounters direct walker usage, not a private `flattenWeeks` re-implementation.
+
+## Directional dependencies on other sub-PRDs
+
+- Upstream: parent #32 (closed) — the named `Plan`, `Mesocycle`, `Fractal`,
+  `Week`, and `TestingPeriod` interfaces are the stable input/output types of
+  the walker. Re-opening #32 is a drift signal per the cycle PRD.
+- Downstream: every later parent issue in this cycle that walks the Plan tree
+  consumes the walker shape this parent stabilises. After this parent's AAR
+  closes, the walker's public surface is stable for the rest of the cycle and
+  re-opening it is a drift signal.
+
+## Domain language
+
+No new domain terms. The walker operates over the existing glossary:
+**Plan**, **Mesocycle**, **Fractal**, **Week**. The "context" attached to
+each yielded Week (mesocycle name, fractal index within mesocycle, absolute
+1-based week index, total weeks) is a presentation of relationships already
+defined in `ubiquitous-language.md` — not a new concept. If during
+implementation a new exposed term emerges (e.g. a name for the per-Week
+context record), validate via `sdp-domain-validate` before closing the
+sub-issue.

--- a/context/cycles/01-deepen-engine/prd.md
+++ b/context/cycles/01-deepen-engine/prd.md
@@ -164,11 +164,10 @@ documented `TS2589` workaround. The CLI shrinks to a thin shell on top.
 
 ## Open questions
 
-- `MUST RESOLVE`: Is the Plan walker exposed as a single iterator
-  (`for (const ctx of walkPlan(plan))`) or as a small object with named
-  reducers (`mapWeeks`, `findWeek`, `flattenWeeks`)? Answer informs every
-  call site in the cycle. To be decided in the Plan-walker sub-PRD via
-  design-it-twice.
+- `RESOLVED IN IMPLEMENTATION`: The Plan walker is exposed as a single eager
+  array primitive, `walkPlan(plan): readonly WeekContext[]`, not a named
+  reducer set. This was decided in parent issue #35 (sub-issue #36) via
+  design-it-twice and captured in ADR 0001.
 - `RESOLVED IN IMPLEMENTATION`: Named `Plan` / `Mesocycle` / `Fractal` /
   `Week` / `TestingPeriod` interfaces live in `plan/types.ts` (parent issue
   #32), and `parsePlan` in `plan/schema.ts` returns the named `Plan`. This

--- a/packages/cli/src/commands/plan/create.ts
+++ b/packages/cli/src/commands/plan/create.ts
@@ -9,6 +9,7 @@ import {
   BUILTIN_TEMPLATES,
   validatePlan,
   reconcile,
+  walkPlan,
   type Plan,
 } from "@run2max/engine";
 
@@ -192,7 +193,7 @@ export default defineCommand({
     const yaml = stringifyYaml(snakePlan);
     await writeFile(filePath, yaml, "utf-8");
 
-    const totalWeeks = plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks)).length;
+    const totalWeeks = walkPlan(plan).length;
     const lastWeek = plan.mesocycles.at(-1)!.fractals.at(-1)!.weeks.at(-1)!;
     const goalLine = plan.goal ? ` — ${plan.goal}` : "";
     process.stderr.write(`created: ${filePath}\n`);

--- a/packages/cli/src/commands/quantify.ts
+++ b/packages/cli/src/commands/quantify.ts
@@ -10,6 +10,7 @@ import {
   scanBlockRuns,
   detectWeekDeviations,
   reportHasAnomalies,
+  walkPlan,
 } from "@run2max/engine";
 import type { OutputFormat, OutputProfileConfig, Plan, MicrocycleConfig } from "@run2max/engine";
 
@@ -292,31 +293,14 @@ async function warnIfPreviousWeekUnsynced(
 
   const prevWeekNumber = currentWeekNumber - 1;
 
-  // Flatten plan weeks
-  const flatWeeks: Array<{
-    absoluteIndex: number;
-    totalWeeks: number;
-    start: string;
-    planned: string;
-    executed?: string;
-  }> = [];
-
-  let idx = 1;
-  for (const meso of plan.mesocycles) {
-    for (const fractal of meso.fractals) {
-      for (const week of fractal.weeks) {
-        flatWeeks.push({
-          absoluteIndex: idx++,
-          totalWeeks: 0,
-          start: week.start,
-          planned: week.planned,
-          executed: week.executed,
-        });
-      }
-    }
-  }
+  const flatWeeks = walkPlan(plan).map((ctx) => ({
+    absoluteIndex: ctx.absoluteIndex,
+    totalWeeks: ctx.totalWeeks,
+    start: ctx.week.start,
+    planned: ctx.week.planned,
+    executed: ctx.week.executed,
+  }));
   const totalWeeks = flatWeeks.length;
-  for (const w of flatWeeks) w.totalWeeks = totalWeeks;
 
   const prevWeek = flatWeeks.find((w) => w.absoluteIndex === prevWeekNumber);
   if (!prevWeek || prevWeek.executed !== undefined) return;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -86,6 +86,8 @@ export { syncWeek, SyncError } from "./plan/sync.js";
 export type { SyncData } from "./plan/sync.js";
 export { adjustPlan, AdjustError } from "./plan/adjust.js";
 export type { AdjustOptions, AdjustResult } from "./plan/adjust.js";
+export { walkPlan } from "./plan/walk.js";
+export type { WeekContext } from "./plan/walk.js";
 export { associateRun, scanBlockRuns, extractDisplayName } from "./plan/associate.js";
 export type { WeekAssociation, BlockRun } from "./plan/associate.js";
 

--- a/packages/engine/src/plan/adjust.test.ts
+++ b/packages/engine/src/plan/adjust.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { parsePlan } from "./schema.js";
 import { validatePlan } from "./validate.js";
 import { adjustPlan, AdjustError } from "./adjust.js";
+import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -309,9 +310,9 @@ describe("adjustPlan", () => {
     expect(result.plan.raceDate).toBe("2026-06-22");
 
     // R week should be on the new race date
-    const rWeek = result.plan.mesocycles
-      .flatMap(m => m.fractals.flatMap(f => f.weeks))
-      .find(w => w.planned === "R");
+    const rWeek = walkPlan(result.plan)
+      .map((c) => c.week)
+      .find((w) => w.planned === "R");
     expect(rWeek?.start).toBe("2026-06-22");
   });
 
@@ -405,9 +406,7 @@ describe("adjustPlan", () => {
 
     if (result.mode !== "plan") throw new Error("expected plan mode");
 
-    const allWeeks = result.plan.mesocycles.flatMap(m =>
-      m.fractals.flatMap(f => f.weeks),
-    );
+    const allWeeks = walkPlan(result.plan).map((c) => c.week);
     const futureWeeks = allWeeks.filter(w => w.executed === undefined);
 
     // R must be on the new race date

--- a/packages/engine/src/plan/adjust.ts
+++ b/packages/engine/src/plan/adjust.ts
@@ -2,6 +2,8 @@ import type { Plan } from "./types.js";
 import type { PlanTemplate } from "./templates/types.js";
 import { reconcile } from "./reconcile.js";
 import type { CompressionOption } from "./reconcile.js";
+import { walkPlan } from "./walk.js";
+import type { WeekContext } from "./walk.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -35,50 +37,8 @@ export class AdjustError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Internal types
-// ---------------------------------------------------------------------------
-
-interface FlatWeek {
-  absoluteIndex: number; // 1-based
-  mesoIndex: number;
-  fractalIndex: number;
-  weekIndex: number;
-  planned: string;
-  start: string;
-  executed?: string;
-  note?: string;
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function flattenWeeks(plan: Plan): FlatWeek[] {
-  const result: FlatWeek[] = [];
-  let idx = 1;
-
-  for (let mi = 0; mi < plan.mesocycles.length; mi++) {
-    const meso = plan.mesocycles[mi]!;
-    for (let fi = 0; fi < meso.fractals.length; fi++) {
-      const fractal = meso.fractals[fi]!;
-      for (let wi = 0; wi < fractal.weeks.length; wi++) {
-        const week = fractal.weeks[wi]!;
-        result.push({
-          absoluteIndex: idx++,
-          mesoIndex: mi,
-          fractalIndex: fi,
-          weekIndex: wi,
-          planned: week.planned,
-          start: week.start,
-          executed: week.executed,
-          note: week.note,
-        });
-      }
-    }
-  }
-
-  return result;
-}
 
 /**
  * Builds a PlanTemplate from the adjustable (future) portion of the plan.
@@ -89,22 +49,29 @@ function flattenWeeks(plan: Plan): FlatWeek[] {
  */
 function extractFutureTemplate(
   plan: Plan,
-  flatWeeks: FlatWeek[],
+  flatWeeks: readonly WeekContext[],
   frontierIdx: number,
 ): PlanTemplate {
   const frontier = flatWeeks[frontierIdx]!;
-  const { mesoIndex: fMi, fractalIndex: fFi, weekIndex: fWi } = frontier;
+  const {
+    mesocycleIndex: frontierMesocycleIndex,
+    fractalIndex: frontierFractalIndex,
+    weekIndex: frontierWeekIndex,
+  } = frontier;
 
   const mesocycles: PlanTemplate["mesocycles"] = [];
 
-  for (let mi = fMi; mi < plan.mesocycles.length; mi++) {
-    const meso = plan.mesocycles[mi]!;
-    const startFi = mi === fMi ? fFi : 0;
+  const frontierAndFutureMesocycles = plan.mesocycles.slice(frontierMesocycleIndex);
+
+  for (let mesocycleOffset = 0; mesocycleOffset < frontierAndFutureMesocycles.length; mesocycleOffset++) {
+    const meso = frontierAndFutureMesocycles[mesocycleOffset]!;
+    const isFrontierMesocycle = mesocycleOffset === 0;
+    const startFi = isFrontierMesocycle ? frontierFractalIndex : 0;
     const fractals: string[][] = [];
 
     for (let fi = startFi; fi < meso.fractals.length; fi++) {
       const fractal = meso.fractals[fi]!;
-      const startWi = mi === fMi && fi === fFi ? fWi : 0;
+      const startWi = isFrontierMesocycle && fi === frontierFractalIndex ? frontierWeekIndex : 0;
       const weekTypes = fractal.weeks.slice(startWi).map((w) => w.planned);
       if (weekTypes.length > 0) {
         fractals.push(weekTypes);
@@ -144,18 +111,22 @@ function clonePlan(plan: Plan): Plan {
  */
 function mergeFrozenAndFuture(
   originalPlan: Plan,
-  flatWeeks: FlatWeek[],
+  flatWeeks: readonly WeekContext[],
   frontierIdx: number,
   futurePlan: Plan,
   newRaceDate?: string,
 ): Plan {
   const frontier = flatWeeks[frontierIdx]!;
-  const { mesoIndex: fMi, fractalIndex: fFi, weekIndex: fWi } = frontier;
+  const {
+    mesocycleIndex: frontierMesocycleIndex,
+    fractalIndex: frontierFractalIndex,
+    weekIndex: frontierWeekIndex,
+  } = frontier;
 
   // Build the frozen mesocycles that come entirely before the frontier mesocycle
   const outputMesos: Plan["mesocycles"] = [];
 
-  for (let mi = 0; mi < fMi; mi++) {
+  for (let mi = 0; mi < frontierMesocycleIndex; mi++) {
     const meso = originalPlan.mesocycles[mi]!;
     outputMesos.push({
       ...meso,
@@ -167,20 +138,22 @@ function mergeFrozenAndFuture(
   }
 
   // Collect frozen fractals from the frontier mesocycle
-  const frontierMeso = originalPlan.mesocycles[fMi]!;
+  const frontierMeso = originalPlan.mesocycles[frontierMesocycleIndex]!;
   const frozenFractals: Plan["mesocycles"][number]["fractals"] = [];
 
   // Fractals entirely before the frontier fractal
-  for (let fi = 0; fi < fFi; fi++) {
+  for (let fi = 0; fi < frontierFractalIndex; fi++) {
     frozenFractals.push({
       weeks: frontierMeso.fractals[fi]!.weeks.map((w) => ({ ...w })),
     });
   }
 
   // Frozen portion of the frontier fractal (if frontier is mid-fractal)
-  if (fWi > 0) {
+  if (frontierWeekIndex > 0) {
     frozenFractals.push({
-      weeks: frontierMeso.fractals[fFi]!.weeks.slice(0, fWi).map((w) => ({ ...w })),
+      weeks: frontierMeso.fractals[frontierFractalIndex]!.weeks
+        .slice(0, frontierWeekIndex)
+        .map((w) => ({ ...w })),
     });
   }
 
@@ -195,7 +168,11 @@ function mergeFrozenAndFuture(
 
     let combinedFractals: Plan["mesocycles"][number]["fractals"];
 
-    if (fWi > 0 && frozenFractals.length > 0 && futureFractalsFromFrontierMeso.length > 0) {
+    if (
+      frontierWeekIndex > 0 &&
+      frozenFractals.length > 0 &&
+      futureFractalsFromFrontierMeso.length > 0
+    ) {
       // Last frozen fractal and first future fractal are both parts of the
       // same original fractal — merge their weeks into a single fractal.
       const mergedBoundaryFractal = {
@@ -247,18 +224,18 @@ function mergeFrozenAndFuture(
  */
 function preserveFutureNotes(
   mergedPlan: Plan,
-  originalFlatWeeks: FlatWeek[],
+  originalFlatWeeks: readonly WeekContext[],
   frontierIdx: number,
 ): Plan {
   // Collect (relativeIdx, planned, note) from original future weeks
   const originalFutureNotes: Array<{ relPos: number; planned: string; note: string }> = [];
   for (let i = frontierIdx; i < originalFlatWeeks.length; i++) {
     const fw = originalFlatWeeks[i]!;
-    if (fw.note !== undefined) {
+    if (fw.week.note !== undefined) {
       originalFutureNotes.push({
         relPos: i - frontierIdx,
-        planned: fw.planned,
-        note: fw.note,
+        planned: fw.week.planned,
+        note: fw.week.note,
       });
     }
   }
@@ -267,15 +244,13 @@ function preserveFutureNotes(
 
   // Flatten future weeks in merged plan
   // Count frozen weeks (those with executed) — the future weeks come after
-  const mergedFlat = mergedPlan.mesocycles.flatMap((m) =>
-    m.fractals.flatMap((f) => f.weeks),
-  );
+  const mergedFlat = walkPlan(mergedPlan).map((ctx) => ctx.week);
 
   const frozenCount = mergedFlat.filter((w) => w.executed !== undefined).length;
 
   // Apply notes where planned type matches at same relative position
   const result = clonePlan(mergedPlan);
-  const resultFlat = result.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks));
+  const resultFlat = walkPlan(result).map((ctx) => ctx.week);
 
   for (const { relPos, planned, note } of originalFutureNotes) {
     const targetIdx = frozenCount + relPos;
@@ -304,10 +279,10 @@ function preserveFutureNotes(
  * @throws AdjustError when no future weeks exist or strategy is impossible
  */
 export function adjustPlan(plan: Plan, options: AdjustOptions): AdjustResult {
-  const flat = flattenWeeks(plan);
+  const flat = walkPlan(plan);
 
   // Find the frontier: first week without executed
-  const frontierIdx = flat.findIndex((w) => w.executed === undefined);
+  const frontierIdx = flat.findIndex((w) => w.week.executed === undefined);
 
   if (frontierIdx === -1) {
     throw new AdjustError(
@@ -317,7 +292,7 @@ export function adjustPlan(plan: Plan, options: AdjustOptions): AdjustResult {
   }
 
   const futureTemplate = extractFutureTemplate(plan, flat, frontierIdx);
-  const startOfFuture = flat[frontierIdx]!.start;
+  const startOfFuture = flat[frontierIdx]!.week.start;
   const effectiveRaceDate = options.raceDate ?? plan.raceDate;
 
   // ── Informational mode ─────────────────────────────────────────────────────

--- a/packages/engine/src/plan/associate.ts
+++ b/packages/engine/src/plan/associate.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseFitBuffer, normalizeFFP } from "normalize-fit-file";
 import type { Plan } from "./types.js";
+import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -77,34 +78,14 @@ export function associateRun(
 ): WeekAssociation | null {
   const localDate = toLocalDate(activityDate, timezone);
 
-  // Flatten all weeks from every mesocycle/fractal with structural metadata.
-  const flatWeeks: Array<{
-    weekNumber: number;
-    weekType: string;
-    mesocycle: string;
-    fractalIndex: number;
-    totalFractals: number;
-    weekStart: string;
-  }> = [];
-
-  let idx = 1;
-  for (const meso of plan.mesocycles) {
-    const totalFractals = meso.fractals.length;
-    let fi = 1;
-    for (const fractal of meso.fractals) {
-      for (const week of fractal.weeks) {
-        flatWeeks.push({
-          weekNumber: idx++,
-          weekType: week.planned,
-          mesocycle: meso.name,
-          fractalIndex: fi,
-          totalFractals,
-          weekStart: week.start,
-        });
-      }
-      fi++;
-    }
-  }
+  const flatWeeks = walkPlan(plan).map((ctx) => ({
+    weekNumber: ctx.absoluteIndex,
+    weekType: ctx.week.planned,
+    mesocycle: ctx.mesocycleName,
+    fractalIndex: ctx.fractalIndex + 1,
+    totalFractals: ctx.totalFractals,
+    weekStart: ctx.week.start,
+  }));
 
   const totalWeeks = flatWeeks.length;
 

--- a/packages/engine/src/plan/build.test.ts
+++ b/packages/engine/src/plan/build.test.ts
@@ -3,6 +3,7 @@ import { buildPlanFromTemplate } from "./build.js";
 import { getBuiltinTemplate } from "./templates/builtin.js";
 import { parsePlan } from "./schema.js";
 import { validatePlan } from "./validate.js";
+import { walkPlan } from "./walk.js";
 
 const MONDAY = "2026-05-04";
 
@@ -10,7 +11,7 @@ describe("buildPlanFromTemplate", () => {
   it("builds a plan from a 1-meso template with correct week count", () => {
     const template = getBuiltinTemplate("1-meso")!;
     const plan = buildPlanFromTemplate(template, { block: "build", start: MONDAY });
-    const weeks = plan.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks));
+    const weeks = walkPlan(plan).map((c) => c.week);
     expect(weeks).toHaveLength(6);
   });
 

--- a/packages/engine/src/plan/reconcile.test.ts
+++ b/packages/engine/src/plan/reconcile.test.ts
@@ -4,6 +4,7 @@ import { getBuiltinTemplate } from "./templates/builtin.js";
 import { parsePlan } from "./schema.js";
 import { validatePlan } from "./validate.js";
 import type { PlanTemplate } from "./templates/types.js";
+import { walkPlan } from "./walk.js";
 
 const TWO_MESO_RACE = getBuiltinTemplate("2-meso-race")!;
 
@@ -16,7 +17,7 @@ const OVERFLOW_BY_2_START = "2026-07-27"; // availableWeeks = 13 → overflow by
 const UNDERFLOW_START = "2026-06-01";   // availableWeeks = 21 → underflow by 6
 
 function allWeeks(plan: ReturnType<typeof reconcile>["plan"]) {
-  return plan!.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks));
+  return walkPlan(plan!).map((c) => c.week);
 }
 
 // ─── exact fit ───────────────────────────────────────────────────────────────
@@ -468,8 +469,6 @@ describe("reconcile — strategy by number", () => {
     const byNumber = reconcile({ ...opts, strategy: "1" });
     expect(byNumber.fit).toBe(byName.fit);
     expect(byNumber.plan?.start).toBe(byName.plan?.start);
-    expect(byNumber.plan?.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks)).length).toBe(
-      byName.plan?.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f.weeks)).length
-    );
+    expect(walkPlan(byNumber.plan!).length).toBe(walkPlan(byName.plan!).length);
   });
 });

--- a/packages/engine/src/plan/reconcile.ts
+++ b/packages/engine/src/plan/reconcile.ts
@@ -75,7 +75,13 @@ function cloneTemplate(t: PlanTemplate): PlanTemplate {
 }
 
 function flatWeeks(template: PlanTemplate): string[] {
-  return template.mesocycles.flatMap((m) => m.fractals.flatMap((f) => f));
+  const weeks: string[] = [];
+  for (const mesocycle of template.mesocycles) {
+    for (const fractal of mesocycle.fractals) {
+      weeks.push(...fractal);
+    }
+  }
+  return weeks;
 }
 
 function raceIndex(template: PlanTemplate): number {

--- a/packages/engine/src/plan/status.ts
+++ b/packages/engine/src/plan/status.ts
@@ -1,6 +1,7 @@
 import type { Plan } from "./types.js";
 import type { DeviationReport } from "./detect.js";
 import { reportHasAnomalies } from "./detect.js";
+import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,42 +79,16 @@ export function getPlanStatus(
   today: string = new Date().toISOString().slice(0, 10),
   options?: PlanStatusOptions,
 ): PlanStatus {
-  // ------------------------------------------------------------------
-  // Flatten weeks with structural context
-  // ------------------------------------------------------------------
-  interface RawEntry {
-    absoluteIndex: number;
-    mesocycleName: string;
-    fractalIndex: number;
-    totalFractals: number;
-    planned: string;
-    start: string;
-    executed?: string;
-    reason?: string;
-  }
-
-  const raw: RawEntry[] = [];
-  let idx = 1;
-
-  for (const meso of plan.mesocycles) {
-    const totalFractals = meso.fractals.length;
-    let fi = 1;
-    for (const fractal of meso.fractals) {
-      for (const week of fractal.weeks) {
-        raw.push({
-          absoluteIndex: idx++,
-          mesocycleName: meso.name,
-          fractalIndex: fi,
-          totalFractals,
-          planned: week.planned,
-          start: week.start,
-          executed: week.executed,
-          reason: week.reason,
-        });
-      }
-      fi++;
-    }
-  }
+  const raw = walkPlan(plan).map((ctx) => ({
+    absoluteIndex: ctx.absoluteIndex,
+    mesocycleName: ctx.mesocycleName,
+    fractalIndex: ctx.fractalIndex + 1,
+    totalFractals: ctx.totalFractals,
+    planned: ctx.week.planned,
+    start: ctx.week.start,
+    executed: ctx.week.executed,
+    reason: ctx.week.reason,
+  }));
 
   const totalWeeks = raw.length;
   const isComplete = raw.every((w) => w.executed !== undefined);

--- a/packages/engine/src/plan/sync.ts
+++ b/packages/engine/src/plan/sync.ts
@@ -1,4 +1,5 @@
 import type { Plan, TestingPeriod } from "./types.js";
+import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -32,37 +33,6 @@ export class SyncError extends Error {
 // ---------------------------------------------------------------------------
 
 const TEST_WEEK_TYPES = new Set(["Ta", "Tb"]);
-
-interface FlatWeek {
-  absoluteIndex: number; // 1-based
-  mesoIndex: number;
-  fractalIndex: number;
-  weekIndex: number;
-  executed?: string;
-}
-
-function flattenWeeks(plan: Plan): FlatWeek[] {
-  const result: FlatWeek[] = [];
-  let idx = 1;
-
-  for (let mi = 0; mi < plan.mesocycles.length; mi++) {
-    const meso = plan.mesocycles[mi]!;
-    for (let fi = 0; fi < meso.fractals.length; fi++) {
-      const fractal = meso.fractals[fi]!;
-      for (let wi = 0; wi < fractal.weeks.length; wi++) {
-        result.push({
-          absoluteIndex: idx++,
-          mesoIndex: mi,
-          fractalIndex: fi,
-          weekIndex: wi,
-          executed: fractal.weeks[wi]!.executed,
-        });
-      }
-    }
-  }
-
-  return result;
-}
 
 /**
  * Finds the index (within the fractal's weeks array) of the last consecutive
@@ -117,10 +87,10 @@ function clonePlan(plan: Plan): Plan {
  * @throws SyncError when the week cannot be synced (already synced or future)
  */
 export function syncWeek(plan: Plan, weekIndex: number, syncData: SyncData): Plan {
-  const flatWeeks = flattenWeeks(plan);
+  const flatWeeks = walkPlan(plan);
 
   // Find the frontier: the first unexecuted week (0-based position in flatWeeks)
-  const frontierFlatIdx = flatWeeks.findIndex((w) => w.executed === undefined);
+  const frontierFlatIdx = flatWeeks.findIndex((w) => w.week.executed === undefined);
 
   // Locate the target week (0-based in flatWeeks)
   const targetFlatIdx = weekIndex - 1;
@@ -131,7 +101,7 @@ export function syncWeek(plan: Plan, weekIndex: number, syncData: SyncData): Pla
   }
 
   // Reject already-synced weeks (executed is frozen)
-  if (target.executed !== undefined) {
+  if (target.week.executed !== undefined) {
     throw new SyncError(
       `week ${weekIndex} is already synced and cannot be modified`,
       "ALREADY_SYNCED",
@@ -149,8 +119,8 @@ export function syncWeek(plan: Plan, weekIndex: number, syncData: SyncData): Pla
 
   const updated = clonePlan(plan);
 
-  const { mesoIndex, fractalIndex, weekIndex: wi } = target;
-  const fractalWeeks = updated.mesocycles[mesoIndex]!.fractals[fractalIndex]!.weeks;
+  const { mesocycleIndex, fractalIndex, weekIndex: wi } = target;
+  const fractalWeeks = updated.mesocycles[mesocycleIndex]!.fractals[fractalIndex]!.weeks;
   const week = fractalWeeks[wi]!;
 
   // Apply execution status and optional fields

--- a/packages/engine/src/plan/validate.ts
+++ b/packages/engine/src/plan/validate.ts
@@ -1,5 +1,7 @@
 import type { Plan, Week } from "./types.js";
 import { EXECUTED_ONLY_TYPES } from "./schema.js";
+import { walkPlan } from "./walk.js";
+import type { WeekContext } from "./walk.js";
 
 export interface Diagnostic {
   code: string;
@@ -12,79 +14,89 @@ const TEST_WEEK_TYPES = new Set(["Ta", "Tb"]);
 
 export function validatePlan(plan: Plan): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
+  const contexts = walkPlan(plan);
 
-  plan.mesocycles.forEach((meso, mi) => {
-    meso.fractals.forEach((fractal, fi) => {
-      const weeks = fractal.weeks;
+  contexts.forEach((ctx, i) => {
+    const week = ctx.week;
+    const path = `mesocycles[${ctx.mesocycleIndex}].fractals[${ctx.fractalIndex}].weeks[${ctx.weekIndex}]`;
 
-      weeks.forEach((week, wi) => {
-        const path = `mesocycles[${mi}].fractals[${fi}].weeks[${wi}]`;
-
-        if (EXECUTED_ONLY_SET.has(week.planned)) {
-          diagnostics.push({
-            code: "EXECUTED_ONLY_AS_PLANNED",
-            message: `"${week.planned}" is an executed-only type and cannot be used as planned`,
-            path: `${path}.planned`,
-          });
-        }
-
-        if (week.reason !== undefined && week.executed !== "INC" && week.executed !== "DNF") {
-          diagnostics.push({
-            code: "REASON_WITHOUT_DEVIATION",
-            message: `reason is only valid when executed is INC or DNF`,
-            path: `${path}.reason`,
-          });
-        }
-
-        if (week.testingPeriod !== undefined) {
-          const isTestWeek = TEST_WEEK_TYPES.has(week.planned);
-
-          if (!isTestWeek) {
-            diagnostics.push({
-              code: "TESTING_PERIOD_ON_NON_TEST_WEEK",
-              message: `testingPeriod is only valid on Ta or Tb weeks`,
-              path: `${path}.testingPeriod`,
-            });
-          } else if (week.executed === "DNF") {
-            diagnostics.push({
-              code: "TESTING_PERIOD_ON_DNF_WEEK",
-              message: `testingPeriod is not valid on a DNF week`,
-              path: `${path}.testingPeriod`,
-            });
-          }
-        }
+    if (EXECUTED_ONLY_SET.has(week.planned)) {
+      diagnostics.push({
+        code: "EXECUTED_ONLY_AS_PLANNED",
+        message: `"${week.planned}" is an executed-only type and cannot be used as planned`,
+        path: `${path}.planned`,
       });
+    }
 
-      weeks.forEach((week, wi) => {
-        if (week.testingPeriod?.cp === undefined) return;
-
-        const path = `mesocycles[${mi}].fractals[${fi}].weeks[${wi}].testingPeriod.cp`;
-        const ta = findPrecedingTa(weeks, wi);
-        if (ta === undefined) return;
-
-        if (ta.executed === "DNF") {
-          diagnostics.push({
-            code: "CP_WITHOUT_TA_EXECUTION",
-            message: `CP cannot be recorded when Ta was DNF`,
-            path,
-          });
-        } else if (ta.executed === "INC" && ta.testingPeriod === undefined) {
-          diagnostics.push({
-            code: "CP_WITHOUT_TA_TEST_PERIOD",
-            message: `CP cannot be recorded when Ta was INC without testingPeriod`,
-            path,
-          });
-        }
+    if (week.reason !== undefined && week.executed !== "INC" && week.executed !== "DNF") {
+      diagnostics.push({
+        code: "REASON_WITHOUT_DEVIATION",
+        message: `reason is only valid when executed is INC or DNF`,
+        path: `${path}.reason`,
       });
-    });
+    }
+
+    if (week.testingPeriod !== undefined) {
+      const isTestWeek = TEST_WEEK_TYPES.has(week.planned);
+
+      if (!isTestWeek) {
+        diagnostics.push({
+          code: "TESTING_PERIOD_ON_NON_TEST_WEEK",
+          message: `testingPeriod is only valid on Ta or Tb weeks`,
+          path: `${path}.testingPeriod`,
+        });
+      } else if (week.executed === "DNF") {
+        diagnostics.push({
+          code: "TESTING_PERIOD_ON_DNF_WEEK",
+          message: `testingPeriod is not valid on a DNF week`,
+          path: `${path}.testingPeriod`,
+        });
+      }
+    }
+
+    if (week.testingPeriod?.cp === undefined) {
+      return;
+    }
+
+    const cpPath = `${path}.testingPeriod.cp`;
+    const ta = findPrecedingTa(contexts, i);
+    if (ta === undefined) {
+      return;
+    }
+
+    if (ta.executed === "DNF") {
+      diagnostics.push({
+        code: "CP_WITHOUT_TA_EXECUTION",
+        message: `CP cannot be recorded when Ta was DNF`,
+        path: cpPath,
+      });
+    } else if (ta.executed === "INC" && ta.testingPeriod === undefined) {
+      diagnostics.push({
+        code: "CP_WITHOUT_TA_TEST_PERIOD",
+        message: `CP cannot be recorded when Ta was INC without testingPeriod`,
+        path: cpPath,
+      });
+    }
   });
 
   return diagnostics;
 }
 
-function findPrecedingTa(weeks: readonly Week[], currentIndex: number): Week | undefined {
+function findPrecedingTa(contexts: readonly WeekContext[], currentIndex: number): Week | undefined {
+  const current = contexts[currentIndex]!;
+
   for (let i = currentIndex - 1; i >= 0; i--) {
-    if (weeks[i]!.planned === "Ta") return weeks[i];
+    const candidate = contexts[i]!;
+    if (
+      candidate.mesocycleIndex !== current.mesocycleIndex ||
+      candidate.fractalIndex !== current.fractalIndex
+    ) {
+      break;
+    }
+    if (candidate.week.planned === "Ta") {
+      return candidate.week;
+    }
   }
+
   return undefined;
 }

--- a/packages/engine/src/plan/walk.test.ts
+++ b/packages/engine/src/plan/walk.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { walkPlan } from "./walk.js";
+import type { Plan } from "./types.js";
+
+describe("walkPlan", () => {
+  it("returns context for a single week", () => {
+    const plan: Plan = {
+      schemaVersion: 1,
+      block: "build",
+      start: "2026-01-05",
+      mesocycles: [
+        {
+          name: "BASE",
+          fractals: [{ weeks: [{ planned: "L", start: "2026-01-05" }] }],
+        },
+      ],
+    };
+
+    const weeks = walkPlan(plan);
+
+    expect(weeks).toEqual([
+      {
+        absoluteIndex: 1,
+        totalWeeks: 1,
+        mesocycleName: "BASE",
+        mesocycleIndex: 0,
+        fractalIndex: 0,
+        totalFractals: 1,
+        weekIndex: 0,
+        week: plan.mesocycles[0]!.fractals[0]!.weeks[0],
+      },
+    ]);
+  });
+
+  it("walks all weeks with stable totalWeeks and absoluteIndex ordering", () => {
+    const plan: Plan = {
+      schemaVersion: 1,
+      block: "build",
+      start: "2026-01-05",
+      mesocycles: [
+        {
+          name: "BASE",
+          fractals: [
+            {
+              weeks: [
+                { planned: "L", start: "2026-01-05" },
+                { planned: "LL", start: "2026-01-12" },
+              ],
+            },
+            {
+              weeks: [{ planned: "D", start: "2026-01-19" }],
+            },
+          ],
+        },
+        {
+          name: "TAPER",
+          fractals: [
+            {
+              weeks: [
+                { planned: "P", start: "2026-01-26" },
+                { planned: "R", start: "2026-02-02" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const weeks = walkPlan(plan);
+
+    expect(weeks).toHaveLength(5);
+    expect(weeks.map((w) => w.absoluteIndex)).toEqual([1, 2, 3, 4, 5]);
+    expect(weeks.map((w) => w.totalWeeks)).toEqual([5, 5, 5, 5, 5]);
+
+    expect(weeks[2]).toMatchObject({
+      absoluteIndex: 3,
+      totalWeeks: 5,
+      mesocycleName: "BASE",
+      mesocycleIndex: 0,
+      fractalIndex: 1,
+      totalFractals: 2,
+      weekIndex: 0,
+    });
+    expect(weeks[2]!.week).toBe(plan.mesocycles[0]!.fractals[1]!.weeks[0]);
+  });
+
+  it("returns an empty array for plans with no mesocycles", () => {
+    const plan = {
+      schemaVersion: 1,
+      block: "build",
+      start: "2026-01-05",
+      mesocycles: [],
+    } as Plan;
+
+    expect(walkPlan(plan)).toEqual([]);
+  });
+});

--- a/packages/engine/src/plan/walk.ts
+++ b/packages/engine/src/plan/walk.ts
@@ -1,0 +1,47 @@
+import type { Plan, Week } from "./types.js";
+
+export interface WeekContext {
+  absoluteIndex: number;
+  totalWeeks: number;
+  mesocycleName: string;
+  mesocycleIndex: number;
+  fractalIndex: number;
+  totalFractals: number;
+  weekIndex: number;
+  week: Week;
+}
+
+export function walkPlan(plan: Plan): readonly WeekContext[] {
+  const result: WeekContext[] = [];
+  const totalWeeks = plan.mesocycles.reduce(
+    (mesoSum, meso) => mesoSum + meso.fractals.reduce((fracSum, fractal) => fracSum + fractal.weeks.length, 0),
+    0,
+  );
+
+  let absoluteIndex = 1;
+
+  for (let mesocycleIndex = 0; mesocycleIndex < plan.mesocycles.length; mesocycleIndex++) {
+    const mesocycle = plan.mesocycles[mesocycleIndex]!;
+    const totalFractals = mesocycle.fractals.length;
+
+    for (let fractalIndex = 0; fractalIndex < mesocycle.fractals.length; fractalIndex++) {
+      const fractal = mesocycle.fractals[fractalIndex]!;
+
+      for (let weekIndex = 0; weekIndex < fractal.weeks.length; weekIndex++) {
+        result.push({
+          absoluteIndex,
+          totalWeeks,
+          mesocycleName: mesocycle.name,
+          mesocycleIndex,
+          fractalIndex,
+          totalFractals,
+          weekIndex,
+          week: fractal.weeks[weekIndex]!,
+        });
+        absoluteIndex++;
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
- Added parent AAR at context/cycles/01-deepen-engine/issues/35-plan-walker/aar.md, documenting outcome, verification rationale, and carry-forward notes.
- Closed the remaining parent flag in context/cycles/01-deepen-engine/issues/35-plan-walker/issue.md:114 with explicit resolution text.
- Updated the cycle PRD open question in context/cycles/01-deepen-engine/prd.md:167 to mark the walker-surface decision as resolved in implementation, with ADR 0001 linkage.
- Net effect: parent #35 is now formally closed, and cycle-level decision tracking is consistent with implemented architecture.

Closes #35 , Closes #36 