### PR TITLE
split-aggregation refactor for engine analysis

### DIFF
--- a/context/adr/0003-split-aggregation-pre-bucketed-input.md
+++ b/context/adr/0003-split-aggregation-pre-bucketed-input.md
@@ -1,0 +1,23 @@
+# Split aggregation uses pre-bucketed input
+
+_Made during: 01-deepen-engine / Parent Issue #38 / Sub-Issue #39_
+_Scope: product_
+_Status: accepted_
+
+The shared split-aggregation primitive is exposed as
+`aggregateBucket(bucket, config): AggregatedFields`, where callers provide one
+already-bucketed list of weighted records. This keeps bucketing ownership in
+`segments.ts`, `km-splits.ts`, and `dynamics.ts` while consolidating
+capability-aware aggregation and derived ratio-of-means fields into one module.
+
+## Considered Options
+
+- Pre-bucketed input (`aggregateBucket(bucket, config)`) — accepted.
+- Strategy-driven bucketing (`aggregateAll(records, strategy, config)`) — rejected because lap-time, km-distance interpolation, and single-bucket classification are not isomorphic under one narrow strategy seam.
+- Two-step public pipeline (`bucketize` + `aggregate`) — rejected because these callers share aggregation but not bucket discovery, so a shared `bucketize` surface adds API without shared leverage.
+
+## Consequences
+
+- Shared Tier-2/Tier-3 gating and weighted/unweighted averaging now live in `computations/aggregate.ts`.
+- Per-call-site bucket discovery remains local and explicit.
+- Dynamics keeps its per-record-mean derived semantics (`avgVerticalRatio`, `avgFormPowerRatio`) at the call site to preserve behavior.

--- a/context/adr/INDEX.md
+++ b/context/adr/INDEX.md
@@ -4,3 +4,4 @@
 | --- | --- | --- | --- | --- |
 | 0001 | Plan walker uses eager array context surface | product | accepted | Standardize Plan-tree traversal on `walkPlan(plan): readonly WeekContext[]` to replace inline loops and private flatten helpers. |
 | 0002 | Plan-family interfaces live in `plan/types.ts` | product | accepted | Keep public Plan domain types as named interfaces in a standalone module, separate from parser/schema definitions. |
+| 0003 | Split aggregation uses pre-bucketed input | product | accepted | Standardize shared aggregation on `aggregateBucket(bucket, config)` while keeping bucket discovery in each computation module. |

--- a/context/cycles/01-deepen-engine/issues/38-split-aggregator/39-implement-split-aggregator/aar.md
+++ b/context/cycles/01-deepen-engine/issues/38-split-aggregator/39-implement-split-aggregator/aar.md
@@ -1,0 +1,6 @@
+1. Did it go as planned? Yes -- sub-issue #39 delivered the planned vertical slice with a shared aggregator module adopted by dynamics, segments, and km-splits while preserving behavior.
+2. What changed from the sub-issue plan: The implementation followed the planned interface and migration order in substance, with one closure-time correction where engine DTS build initially failed on optional `weight` typing in `km-splits.ts` and was fixed by defaulting missing weights to `1` at duration summation.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - ADR 0003 was added to capture the pre-bucketed-shape decision and rejected alternatives (`context/adr/INDEX.md`).
+   - Parent close should mark the cycle PRD split-aggregator open question as resolved in implementation.
+   - No unresolved outward flags were identified for active siblings under this parent (none planned).

--- a/context/cycles/01-deepen-engine/issues/38-split-aggregator/39-implement-split-aggregator/sub-issue.md
+++ b/context/cycles/01-deepen-engine/issues/38-split-aggregator/39-implement-split-aggregator/sub-issue.md
@@ -1,0 +1,442 @@
+# Sub-Issue #39 — Implement and adopt the split-aggregation primitive
+
+Vertical slice for parent issue #38. Delivers the full parent scope as a
+single behaviour-preserving change: design the aggregator, implement it,
+migrate `dynamics.ts` (single-bucket tracer), then `segments.ts`
+(unweighted multi-bucket) and `km-splits.ts` (weighted multi-bucket),
+and export the aggregator under the engine's Analysis output grouping.
+
+## Description
+
+Introduce a single split-aggregation primitive in `@run2max/engine`. The
+primitive consumes one bucket of records (each with an optional fractional
+weight) plus an aggregation config, and returns the shared aggregated
+field set: power, heart rate, cadence, Tier-2 dynamics, Tier-3 dynamics,
+and the two derived metrics (`verticalRatio`, `formPowerRatio`).
+Capability gating (Tier-2 / Tier-3) lives inside the aggregator.
+
+Each existing call site keeps its own bucketing logic (the part that is
+genuinely different) and its own row-shape post-processing (per-bucket
+fields like `lapIndex` / `km` / `distance` / `duration` / `avgPace` /
+elevation / weather null-placeholders). Aggregation itself is shared.
+
+The scope is a vertical slice — every concrete acceptance criterion of
+parent #38 is closed by this sub-issue. If implementation reveals the
+slice is too large (e.g. the weighted-vs-unweighted unification uncovers
+a shape mismatch the aggregator cannot bridge cleanly), it splits and a
+sibling sub-issue is added under parent #38. Today, only this sub-issue
+is planned.
+
+## Dependency classification
+
+| Dependency | Category | Testing strategy |
+| --- | --- | --- |
+| TypeScript compiler | In-process | Test directly: type-check is part of `pnpm test`. |
+| `vitest` | In-process | Existing engine and CLI test suites run as-is. |
+| `Run2MaxRecord` (from `normalize-fit-file`, re-exported via `engine/types.ts`) | In-process | Test directly: aggregator input is `Run2MaxRecord` shape, already exercised by existing fixtures. |
+| `DataCapabilities` and `ZoneConfig` (engine/types.ts) | In-process | Test directly: capability gates are passed through aggregator config. |
+| Existing `computations/segments.ts`, `computations/km-splits.ts`, `computations/dynamics.ts` test suites | In-process | Test directly: existing per-module tests are the migration's regression net. |
+| Existing `computations/quantify.test.ts` | In-process | Test directly: end-to-end aggregation across a real Run is exercised here. |
+
+No remote, collaborator-owned, or external dependencies. No port required —
+no second adapter is in play. The aggregator is pure data transformation
+over already-bucketed records.
+
+## Interface design
+
+The interface this sub-issue must commit to is the aggregator's *input
+shape*, *config shape*, and *output shape*. The runtime contract of every
+migrated call site does not change: `SegmentRow`, `KmSplitRow`, and
+`DynamicsSummary` shapes in `engine/types.ts` are unchanged.
+
+### Design-it-twice
+
+**Alternative A — Pre-bucketed input: `aggregateBucket(bucket, config): AggregatedFields`**
+
+The aggregator takes one already-formed bucket (a list of records, each
+with an optional weight) plus a config flag set, and returns the shared
+aggregated field set. Callers do their own bucketing and call the
+aggregator once per bucket.
+
+```ts
+export interface WeightedRecord {
+  record: Run2MaxRecord;
+  weight?: number; // 0..1, defaults to 1 (unweighted)
+}
+
+export interface AggregationConfig {
+  capabilities: DataCapabilities;
+  zones?: ZoneConfig[]; // when present, classifies avgPower into a zone
+}
+
+export interface AggregatedFields {
+  // Always present (Tier 1)
+  avgPower: number | null;
+  zone: string | null;          // null when no zones config or no power
+  avgHeartRate: number | null;
+  avgCadence: number | null;
+  // Tier 2 (null when !capabilities.hasRunningDynamics)
+  avgStanceTime: number | null;
+  avgStanceTimeBalance: number | null;
+  avgStepLength: number | null;
+  avgVerticalOscillation: number | null;
+  // Tier 3 (null when !capabilities.hasStrydEnhanced)
+  avgFormPower: number | null;
+  avgAirPower: number | null;
+  // Derived
+  verticalRatio: number | null; // (vo / sl) * 100, requires Tier 2
+  formPowerRatio: number | null; // formPower / power, requires Tier 3
+}
+
+export function aggregateBucket(
+  bucket: readonly WeightedRecord[],
+  config: AggregationConfig,
+): AggregatedFields;
+```
+
+For dynamics' extra Tier-3 fields (`legSpringStiffness`,
+`legSpringStiffnessBalance`, `verticalOscillationBalance`), the dynamics
+call site computes those at the call site after `aggregateBucket`
+returns. They are dynamics-only (`SegmentRow` and `KmSplitRow` do not
+carry them) so widening `AggregatedFields` to hold them would force
+segments and km-splits to ignore three always-null fields. Better to
+keep them where they are used.
+
+- Leverage: high — one symbol covers every bucket-aggregation site. The
+  three call sites stay clean: each owns its own bucketing and its own
+  row-shape post-processing.
+- Locality: high — aggregator module is the single home of capability
+  gating and field averaging. No second module to keep in sync.
+- Testability: simple — a small focused unit test on a fixture record
+  set with mixed weights validates the shape; every migrated call
+  site's existing test is the end-to-end behaviour-preservation net.
+
+**Alternative B — `bucketBy` strategy: `aggregateAll(records, config): AggregatedFields[]`**
+
+The aggregator takes the full `Run2MaxRecord[]` plus a `bucketBy`
+function returning bucket keys (or boundaries), performs the bucketing,
+and returns one `AggregatedFields` per bucket.
+
+```ts
+export interface BucketStrategy {
+  // Returns the bucket index (0-based) for a given record.
+  // Returns -1 to skip the record.
+  bucketOf(record: Run2MaxRecord, prev: Run2MaxRecord | null, index: number): number;
+  // Optional: return a partial weight for split-edge interpolation.
+  weightOf?(record: Run2MaxRecord, prev: Run2MaxRecord | null, bucketIndex: number): number;
+}
+
+export function aggregateAll(
+  records: readonly Run2MaxRecord[],
+  strategy: BucketStrategy,
+  config: AggregationConfig,
+): AggregatedFields[];
+```
+
+- Leverage: medium — the aggregator owns more, but the three call
+  sites' bucketing strategies are not isomorphic. Lap time-windowing
+  classifies records by the *next* lap-start timestamp; km
+  distance-windowing splits records *across* boundaries with two-sided
+  fractional weights; dynamics is a single bucket. Stuffing all three
+  into one strategy interface either widens it to absorb every edge
+  case (and now bucket discovery lives in two places, badly) or forces
+  the km-splits edge-interpolation logic to live awkwardly inside a
+  `weightOf` callback.
+- Locality: medium — bucketing logic and aggregation logic merge into
+  one module, but only one of the three call sites (dynamics) is
+  served simply. The other two pay an indirection cost.
+- Testability: harder — testing the aggregator now requires fixture
+  records *plus* a strategy mock; the strategy interface is a
+  test-surface widening that A avoids.
+
+**Alternative C — Two-step pipeline: `bucketize` + `aggregate` separately exported**
+
+Two functions: `bucketize(records, strategy): WeightedRecord[][]` and
+`aggregate(buckets, config): AggregatedFields[]`. Callers compose.
+
+- Leverage: low — `bucketize` for segments and km-splits would still
+  hold both lap-time-windowing and km-distance-windowing logic
+  side-by-side, requiring a discriminator. Dynamics doesn't need
+  `bucketize` at all (it just wraps `records` in a `WeightedRecord[]`
+  with weight=1 and passes one bucket). The two-step shape is correct
+  in principle but the bucketing step is not actually shared between
+  segments and km-splits — they share *zero* bucketing logic, only
+  aggregation.
+- Locality: low — splits the "obviously one thing" (aggregation) into
+  two functions where one would do.
+- Testability: identical to A on the aggregation side, plus a
+  `bucketize` surface that adds nothing.
+
+### Choice
+
+**A (pre-bucketed input).** The three call sites do not share bucketing
+logic — they share aggregation logic. Folding aggregation out (A)
+matches the actual deepening: one symbol, one home for capability
+gating and Tier-2/Tier-3 averaging, three call sites that keep their
+genuinely-different bucketing where it lives. B forces bucketing
+discovery into the aggregator and pays for it at every site that has
+non-trivial bucketing. C splits one thing into two without shared
+bucketing logic to justify the split.
+
+B is rejected in one sentence: bucketing strategies for lap-time,
+km-distance, and single-bucket are not isomorphic and a `BucketStrategy`
+interface wide enough to hold all three is wider than the three
+inline implementations it replaces.
+
+C is rejected in one sentence: segments and km-splits share aggregation
+but not bucketing, so a separately-exported `bucketize` step has no
+shared callers — it adds a public surface with one consumer each.
+
+This decision answers the cycle PRD's `MUST RESOLVE` open question on
+the unified split-aggregator parameter shape; once parent #38 closes,
+update `context/cycles/01-deepen-engine/prd.md` to mark it resolved.
+
+The choice is a candidate ADR per the cycle PRD; rationale captured here
+is the seed for that ADR if one is written at parent close.
+
+### Aggregator location
+
+`packages/engine/src/computations/aggregate.ts` — a new module.
+`AggregatedFields`, `WeightedRecord`, `AggregationConfig`, and
+`aggregateBucket` live there. The aggregator does not belong in
+`computations/utils.ts` because it is a domain-aware operation
+(capability gating, Tier-2/Tier-3 field set, derived metrics), not a
+generic numerical helper like `avg` or `rollingWindowPeak`.
+
+Rejected: putting `aggregateBucket` in `computations/utils.ts`. One
+sentence: `utils.ts` holds capability-agnostic numerical primitives;
+the aggregator is capability-aware and would force `utils.ts` to import
+domain types.
+
+### Public interface
+
+```ts
+// packages/engine/src/computations/aggregate.ts
+import type {
+  Run2MaxRecord,
+  DataCapabilities,
+  ZoneConfig,
+} from "../types.js";
+
+export interface WeightedRecord {
+  record: Run2MaxRecord;
+  weight?: number; // defaults to 1
+}
+
+export interface AggregationConfig {
+  capabilities: DataCapabilities;
+  zones?: ZoneConfig[];
+}
+
+export interface AggregatedFields {
+  avgPower: number | null;
+  zone: string | null;
+  avgHeartRate: number | null;
+  avgCadence: number | null;
+  avgStanceTime: number | null;
+  avgStanceTimeBalance: number | null;
+  avgStepLength: number | null;
+  avgVerticalOscillation: number | null;
+  avgFormPower: number | null;
+  avgAirPower: number | null;
+  verticalRatio: number | null;
+  formPowerRatio: number | null;
+}
+
+export function aggregateBucket(
+  bucket: readonly WeightedRecord[],
+  config: AggregationConfig,
+): AggregatedFields;
+```
+
+Invariants:
+- `aggregateBucket(bucket, config)` returns the shared field set. Every
+  field's value is `null` if no record in the bucket has a non-null
+  value for the underlying metric *or* the relevant capability flag
+  (`hasRunningDynamics` for Tier 2, `hasStrydEnhanced` for Tier 3) is
+  false.
+- A `WeightedRecord` with `weight === undefined` is treated as
+  `weight = 1`. All-unweighted input produces the same output as a
+  plain arithmetic mean across the bucket.
+- A bucket of mixed weights produces a weighted mean: `sum(value *
+  weight) / sum(weight)` for each field, computed per-field so a record
+  contributing `null` for one field does not poison its weight
+  contribution to other fields.
+- `zone` is `null` unless `config.zones` is provided *and* `avgPower` is
+  non-null. Zone classification uses `classifyPowerZone` (already in
+  `computations/zones.ts`), unchanged.
+- `verticalRatio` is `(avgVerticalOscillation / avgStepLength) * 100`
+  when both are non-null and `avgStepLength > 0`; otherwise `null`.
+- `formPowerRatio` is `avgFormPower / avgPower` when both are non-null
+  and `avgPower > 0`; otherwise `null`. (Note: today's `dynamics.ts`
+  computes `avgFormPowerRatio` as the *mean of per-record ratios*, not
+  as the ratio of means. See "behaviour preservation" below — the
+  aggregator must preserve the *segment/km-split* semantic, and
+  dynamics must continue to compute its `avgFormPowerRatio` and
+  `avgVerticalRatio` *itself* if it needs the per-record-mean form.)
+
+Error modes:
+- `aggregateBucket` does not throw. An empty bucket returns all-null
+  fields. A bucket of records with all-null values for a metric
+  returns null for that metric.
+
+### Behaviour preservation
+
+Today's three sites differ subtly on the derived metrics
+(`verticalRatio`, `formPowerRatio`):
+
+- `segments.ts` and `km-splits.ts` compute `verticalRatio` and
+  `formPowerRatio` as the **ratio of (weighted) means**:
+  `(avgVerticalOscillation / avgStepLength) * 100` and
+  `avgFormPower / avgPower`.
+- `dynamics.ts` computes `avgVerticalRatio` and `avgFormPowerRatio` as
+  the **mean of per-record ratios**:
+  `mean(verticalOscillation_i / stepLength_i)` (and similarly for
+  formPower). The output field names also differ
+  (`avgVerticalRatio`, `avgFormPowerRatio` vs `verticalRatio`,
+  `formPowerRatio`).
+
+These are different semantics. Byte-identity preservation requires
+keeping both. The aggregator returns the **ratio-of-means** form
+(matching segments and km-splits, the two callers that put it in their
+public output as `verticalRatio` / `formPowerRatio`). The dynamics call
+site continues to compute `avgVerticalRatio` and `avgFormPowerRatio` at
+the call site for its `DynamicsSummary` output, using a small private
+helper. The aggregator's `verticalRatio` and `formPowerRatio` fields
+are simply unused by the dynamics consumer.
+
+This is a deliberate choice: unifying the two semantics behind one name
+would violate "no behaviour change" (cycle PRD, success metrics). The
+divergence is recorded here so a future cycle can decide which
+semantic is canonical and reduce again.
+
+## Acceptance criteria
+
+- `packages/engine/src/computations/aggregate.ts` exists and exports
+  `WeightedRecord`, `AggregationConfig`, `AggregatedFields`, and
+  `aggregateBucket` as specified above.
+- `packages/engine/src/index.ts` re-exports the aggregator's public
+  symbols under the Analysis output grouping.
+- `packages/engine/src/computations/segments.ts` consumes
+  `aggregateBucket` to produce `SegmentRow` fields. The lap-time
+  bucketing logic stays. The `buildSegmentRow` body's Tier-2 / Tier-3
+  / derived-metrics block is replaced by one `aggregateBucket` call;
+  per-bucket fields (`lapIndex`, `distance`, `duration`, `avgPace`,
+  elevation, weather null-placeholders) stay at the call site.
+- `packages/engine/src/computations/km-splits.ts` consumes
+  `aggregateBucket`. The `weightedAvg` helper is deleted. The
+  km-distance bucketing logic and `WeightedRecord[][]` construction
+  stays at the call site (now using the aggregator's exported
+  `WeightedRecord` type rather than the private one).
+- `packages/engine/src/computations/dynamics.ts` consumes
+  `aggregateBucket` for the shared field set, mapping the bucket-level
+  output into `DynamicsSummary` (renaming `avgPower` → not used,
+  `avgStanceTime` → `avgStanceTime`, etc.). The Tier-3 extras
+  (`avgLegSpringStiffness`, `avgLegSpringStiffnessBalance`,
+  `avgVerticalOscillationBalance`) stay at the call site.
+  `avgFormPowerRatio` and `avgVerticalRatio` (per-record-mean form)
+  stay at the call site as documented.
+- The duplicated `getDistance(record)` helper (`segments.ts:15`,
+  `km-splits.ts:16`) is *not* consolidated by this sub-issue — it
+  remains where it is. Flagged for the helper-consolidation parent.
+- `pnpm test` succeeds at the workspace root with no test
+  modifications beyond mechanical replacements where they apply (most
+  tests should require zero changes since output shapes are
+  unchanged).
+- Output of `quantify` for the existing engine fixtures is
+  byte-identical to pre-aggregator output. Verified by running
+  `quantify` against a fixture and diffing JSON output.
+- Grep for `weightedAvg` outside `aggregate.ts` returns nothing in
+  `packages/engine/src/`. Grep for the Tier-2 averaging pattern
+  (`stanceTime ?? null`, `stepLength ?? null`, `verticalOscillation ?? null`
+  appearing in proximity) returns no matches outside `aggregate.ts` in
+  the engine source.
+- TypeScript strict mode stays on. `TS2589` is not emitted at any point
+  during the change.
+
+## Proposed tests
+
+1. **Aggregator unit test (new)** —
+   `packages/engine/src/computations/aggregate.test.ts`. Construct
+   small fixture buckets and assert:
+   - All-Tier-1 records, no zones config: `avgPower`, `avgHeartRate`,
+     `avgCadence` are arithmetic means; `zone` is `null`; Tier-2 and
+     Tier-3 fields are `null` (capability gate off).
+   - All-Tier-1 records, with `capabilities.hasRunningDynamics = true`
+     but no Tier-2 fields on records: Tier-2 fields are `null`.
+   - Mixed Tier-2 / Tier-3 records with capabilities on: averages match
+     hand-computed values; `verticalRatio` and `formPowerRatio` match
+     ratio-of-means semantics.
+   - Weighted bucket (weights 0.5 / 0.5 / 1): output equals weighted
+     mean, not arithmetic mean. Per-field weight contribution is not
+     poisoned by `null`s in other fields.
+   - Empty bucket: all fields `null`.
+   - Bucket with `weight = undefined` for every record: output equals
+     unweighted mean.
+2. **Existing per-module tests pass unchanged.**
+   `computations/segments.test.ts`, `computations/km-splits.test.ts`,
+   and `computations/dynamics.test.ts` continue to pass without
+   behavioural modification. Where they currently spot-check Tier-2 /
+   Tier-3 / derived fields on the row output, those assertions now
+   exercise the aggregator transitively.
+3. **Existing `quantify.test.ts` passes unchanged.** Whole-Run
+   aggregation across a real fixture is the integration regression net.
+4. **Fixture byte-identity check.** Run `quantify` against the engine's
+   existing fixture(s) pre-change and post-change; JSON output diff
+   must be empty. (Manual verification step rather than a new automated
+   test — the cycle PRD's non-goals exclude introducing an end-to-end
+   byte-diff harness.)
+5. **No new behavioural test is added.** This sub-issue is a refactor;
+   new behaviour would be scope drift. If existing test coverage gaps
+   are discovered (e.g. dynamics' per-record-mean ratio semantic is
+   not explicitly asserted today), record the gap as a flag on parent
+   #38 rather than expanding this sub-issue.
+
+## Affected artifacts
+
+- `packages/engine/src/computations/aggregate.ts` — **new file**, holds
+  `WeightedRecord`, `AggregationConfig`, `AggregatedFields`, and
+  `aggregateBucket`.
+- `packages/engine/src/computations/aggregate.test.ts` — **new file**,
+  aggregator unit tests.
+- `packages/engine/src/computations/segments.ts` — replace
+  `buildSegmentRow`'s Tier-2 / Tier-3 / derived block (lines ~85–122)
+  with one `aggregateBucket` call. Wrap each lap's `Run2MaxRecord[]`
+  bucket in `WeightedRecord[]` with `weight = 1` (or omit `weight`,
+  letting the default apply). Keep `lapIndex`, `distance`, `duration`,
+  `avgPace`, elevation, and weather null-placeholders at the call
+  site. The local `getDistance` and `toMs` helpers stay.
+- `packages/engine/src/computations/km-splits.ts` — delete the private
+  `weightedAvg` (lines 92–108) and the local `WeightedRecord` interface
+  (lines 24–27). Import `WeightedRecord` and `aggregateBucket` from
+  `aggregate.ts`. Replace `buildKmSplitRow`'s Tier-2 / Tier-3 / derived
+  block (lines ~127–164) with one `aggregateBucket` call. Keep `km`,
+  `distance`, `duration`, `avgPace`, elevation, and weather
+  null-placeholders at the call site. The bucketing logic
+  (lines 38–85) stays. The local `getDistance` stays.
+- `packages/engine/src/computations/dynamics.ts` — replace the Tier-2
+  averaging block (lines 17–31), the Tier-3 averaging block
+  (lines 33–45), and the derived-metric blocks for `avgFormPowerRatio`
+  and `avgVerticalRatio` *only insofar as they overlap the aggregator's
+  output*. Keep `avgVerticalOscillationBalance`,
+  `avgLegSpringStiffness`, `avgLegSpringStiffnessBalance` at the call
+  site (Tier-3 dynamics-only fields the aggregator does not produce).
+  Keep `avgFormPowerRatio` and `avgVerticalRatio` at the call site
+  with their per-record-mean semantic intact (do not switch to the
+  aggregator's ratio-of-means form — that would change behaviour).
+  Wrap `records` in a single `WeightedRecord[]` bucket with weight = 1
+  per record; call `aggregateBucket` once.
+- `packages/engine/src/index.ts` — re-export `WeightedRecord`,
+  `AggregationConfig`, `AggregatedFields`, and `aggregateBucket` from
+  `computations/aggregate.js` under the existing Analysis output
+  grouping (alongside `SegmentRow`, `KmSplitRow`, `DynamicsSummary`).
+
+## Dependencies
+
+- Upstream sub-issues: parent #32 / sub-issue #33 (closed) — the
+  engine's domain-type discipline is the baseline. Parent #35 / sub-issue
+  #36 (closed) — not on this path; aggregator does not touch Plan trees.
+- External services: none.
+- Test fixtures: existing engine fixtures are reused unchanged. The
+  aggregator unit test introduces small in-test record fixtures rather
+  than new `.fit` files.

--- a/context/cycles/01-deepen-engine/issues/38-split-aggregator/aar.md
+++ b/context/cycles/01-deepen-engine/issues/38-split-aggregator/aar.md
@@ -1,0 +1,6 @@
+1. Did it go as planned? Yes -- sub-issue #39 delivered the full planned scope and parent #38 acceptance criteria are met.
+2. What changed from the parent issue plan: The migration remained behavior-preserving and localized as planned; one additional verification surfaced during closure where `pnpm test` was green but engine DTS build failed under strict optional-weight typing, and this was corrected before closure.
+3. ADRs made during this parent issue (reference INDEX.md rows): ADR 0003 (Split aggregation uses pre-bucketed input) was added and accepted (`context/adr/INDEX.md`).
+4. New considerations or constraints surfaced: Closure checks for refactor parents should include both repository tests and package-level build+DTS validation because type-surface changes can pass tests but fail declaration builds.
+5. Patterns across sub-issue AARs: The highest-leverage deepening remained a single seam (`aggregateBucket`) with call sites retaining genuinely distinct bucket discovery logic.
+6. Carry-forward -- flags to write in the cycle, notes for the PRD AAR: The cycle PRD `MUST RESOLVE` split-aggregator parameter-shape question is now resolved in implementation (pre-bucketed input).

--- a/context/cycles/01-deepen-engine/issues/38-split-aggregator/issue.md
+++ b/context/cycles/01-deepen-engine/issues/38-split-aggregator/issue.md
@@ -1,0 +1,147 @@
+# Parent Issue #38 — Split-aggregation primitive
+
+> Technical execution doc. Sub-issues live in sibling `XX-...` folders.
+
+## Acceptance criteria
+
+- A single split-aggregation primitive is exported from `@run2max/engine`
+  and consumed by `computations/segments.ts`, `computations/km-splits.ts`,
+  and `computations/dynamics.ts`. The primitive is parameterised by
+  bucketing input only — the aggregation logic itself (Tier-2 / Tier-3
+  capability gating, derived metrics, average vs weighted-average choice)
+  lives in one module.
+- The Tier-2 averaging block (`stanceTime`, `stanceTimeBalance`,
+  `stepLength`, `verticalOscillation`) appears once in the codebase. The
+  Tier-3 averaging block (`formPower`, `airPower`, plus dynamics-only
+  `legSpringStiffness` / `legSpringStiffnessBalance` /
+  `verticalOscillationBalance`) appears once. The derived-metric
+  expressions for `verticalRatio` and `formPowerRatio` appear once.
+- The two private `weightedAvg` (`computations/km-splits.ts:92`) and
+  inline-`avg`-mapping (`computations/segments.ts:79-117`,
+  `computations/dynamics.ts:17-77`) idioms are deleted from their
+  call-site files. Each call site retains only its bucketing logic and
+  a call into the shared aggregator.
+- `SegmentRow`, `KmSplitRow`, and `DynamicsSummary` shapes in
+  `packages/engine/src/types.ts` are unchanged. The aggregator produces
+  the same field set each call site produces today — no new fields, no
+  removed fields, no rename. Output of `quantify` against existing
+  fixtures stays byte-identical.
+- The aggregator handles the unweighted case (segments, dynamics) and
+  the weighted case (km-splits) without forking on a boolean — weight
+  is part of the input shape, defaulting to `1` for unweighted callers.
+  Weighted-average and arithmetic-average semantics are unified at the
+  aggregator's boundary.
+- The aggregator does not own bucket discovery. Lap-time-windowing
+  (segments), km-distance-windowing with fractional weights (km-splits),
+  and single-bucket (dynamics) bucketing logic stays in each respective
+  computation module. The aggregator's input is already-bucketed.
+- The cycle PRD's `MUST RESOLVE` open question — "shape of the unified
+  split-aggregator parameter: `bucketBy` strategy function vs pre-bucketed
+  `Slice[]` input" — is answered in sub-issue #39's design-it-twice
+  record with a one-sentence rejection rationale for the alternative.
+- All existing tests pass without behavioural modification:
+  `computations/segments.test.ts`, `computations/km-splits.test.ts`,
+  `computations/dynamics.test.ts`, `computations/quantify.test.ts`,
+  the engine smoke test, and CLI command tests. Workspace-level
+  `pnpm test` is green.
+- TypeScript strict mode stays on. `TS2589` does not regress.
+- Engine public exports under the Analysis output grouping include the
+  aggregator primitive and any shared input/output types it requires.
+  No additional helpers leak: any per-call-site post-processing (e.g.
+  filling `windSpeed`/`windDirection`/`temperature` from weather data)
+  stays at the call site.
+
+## Implementation approach
+
+1. In sub-issue #39, design-it-twice the aggregator's public surface.
+   At minimum compare:
+   - Alternative A — **pre-bucketed input**: the aggregator takes
+     `WeightedRecord[]` (a bucket) plus an aggregation config and
+     returns the aggregated row for that bucket. Callers do their own
+     bucketing and call the aggregator once per bucket.
+   - Alternative B — **`bucketBy` strategy**: the aggregator takes the
+     full `Run2MaxRecord[]` plus a `bucketBy` function returning bucket
+     keys, performs the bucketing, and returns one row per bucket.
+   Record the chosen design and a one-sentence rejection rationale for
+   the other. The sub-PRD records a pre-resolution preference for A;
+   the design-it-twice must reach its own decision rather than ratify
+   the preference.
+2. Define the aggregator's input record shape (likely something like
+   `WeightedRecord = { record: Run2MaxRecord; weight: number }`) and
+   the output shape contract. The output shape is a *superset* of the
+   shared field set; per-call-site fields not produced by the
+   aggregator (`lapIndex`, `km`, `distance`, `duration`, `avgPace`,
+   elevation, weather null-placeholders) are added by the call site
+   after aggregation.
+3. Implement the aggregator in a single module. Decide between adding
+   to `computations/utils.ts` versus a new
+   `computations/aggregate.ts` (or similar) during sub-issue interface
+   design; record the rejected alternative.
+4. Migrate call sites in dependency order:
+   1. `computations/dynamics.ts` first — single-bucket case is the
+      simplest consumer and a useful smoke for the aggregator's shape.
+   2. `computations/segments.ts` — unweighted multi-bucket. Bucketing
+      logic (lap time-windowing) stays. The aggregator replaces the
+      Tier-2 / Tier-3 / derived-metrics block.
+   3. `computations/km-splits.ts` — weighted multi-bucket. Bucketing
+      logic (km distance-windowing with fractional weights) stays.
+      Per-bucket `WeightedRecord` construction stays at the call site.
+      The aggregator replaces `weightedAvg` and the field-by-field
+      averaging block.
+5. After each migration, run the relevant test file and confirm green
+   before moving to the next call site. Confirm fixture byte-identity
+   for `quantify` output against the existing engine fixtures at the
+   end of the migration.
+6. Export the aggregator primitive (and any shared input/output types)
+   from `packages/engine/src/index.ts` under the Analysis output
+   grouping.
+7. Run `pnpm test` at the workspace root and confirm green.
+
+If during implementation the migration decomposes into more than one
+vertical slice (e.g. dynamics-first as a tracer bullet, then segments
+and km-splits in a second slice), additional sub-issues are added as
+siblings to #39.
+
+## Dependencies
+
+- Upstream: parent #32 (closed) — named Plan-family interfaces are not
+  on this path, but the engine's domain-type discipline established
+  there extends to the aggregator's input/output types: no
+  `v.InferOutput` chains, no structural-subtype workarounds.
+- Upstream: none of parent #35's walker work is required here. This
+  primitive operates on `Run2MaxRecord[]`, not on Plan trees.
+- External: `valibot` untouched. `normalize-fit-file` untouched —
+  `Run2MaxRecord` is the consumed shape.
+- Tooling: `pnpm test` / `vitest` for repository-runnable verification.
+  (`pnpm typecheck` is not a defined workspace command — see parent
+  #32's closure flag.)
+
+## Flags
+
+- Once this parent closes, the aggregator's input/output shapes are
+  stable for the rest of the cycle. Later parents (engine/presentation
+  split, helper consolidation, public-export rewrite) consume the
+  shapes settled here. Re-introducing a bespoke field-averaging block
+  in a downstream parent is a drift signal — flag it.
+- The aggregator parent does not own `getDistance(record)` consolidation.
+  That helper currently appears in `computations/segments.ts:15`,
+  `computations/km-splits.ts:16`, and `computations/elevation.ts:14`.
+  Resolve in the helper-consolidation parent of this cycle. The
+  aggregator parent may co-locate one local copy if the seam genuinely
+  needs it; do not eagerly consolidate across modules from here.
+- The aggregator's design-it-twice answers the cycle PRD's `MUST RESOLVE`
+  on parameter shape (bucketBy vs pre-bucketed). After this parent
+  closes, update `context/cycles/01-deepen-engine/prd.md` to mark the
+  question resolved with the chosen shape.
+- If the aggregator decision merits an ADR (per cycle-PRD policy:
+  decisions hard to reverse, surprising without context, and the
+  result of a real trade-off), `sdp-adr` runs at parent close. The
+  bucketing-shape decision is a likely ADR candidate.
+- If the migration uncovers a shape mismatch between `SegmentRow` and
+  `KmSplitRow` that the aggregator cannot bridge without renaming a
+  field, that is scope creep into type unification. Flag it as a
+  follow-up rather than expanding this parent.
+- The dynamics-first sub-issue ordering treats the single-bucket case
+  as a tracer bullet. If sub-issue #39 holds the full migration and
+  the tracer is implicit, that is fine; if a second sub-issue is
+  needed, it is sequenced as #40 after #39's tracer-only scope closes.

--- a/context/cycles/01-deepen-engine/issues/38-split-aggregator/sub-prd.md
+++ b/context/cycles/01-deepen-engine/issues/38-split-aggregator/sub-prd.md
@@ -1,0 +1,104 @@
+# Parent Issue #38 — Split-aggregation primitive
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## Scope
+
+Collapse the three near-identical row-building paths in `@run2max/engine`
+into a single split-aggregation primitive parameterised by bucketing
+strategy. Today the same Tier-aware aggregation logic is restated three
+times across:
+
+- `packages/engine/src/computations/segments.ts` — lap-bucketed records,
+  unweighted `avg`, produces `SegmentRow`.
+- `packages/engine/src/computations/km-splits.ts` — distance-bucketed records
+  with fractional weights, custom `weightedAvg`, produces `KmSplitRow`.
+- `packages/engine/src/computations/dynamics.ts` — single-bucket (whole-Run)
+  records, unweighted `avg`, produces `DynamicsSummary`.
+
+All three repeat the same capability gating (Tier 2 / Tier 3), the same
+field list (`stanceTime`, `stanceTimeBalance`, `stepLength`,
+`verticalOscillation`, `formPower`, `airPower`), and the same derived
+metrics (`verticalRatio`, `formPowerRatio`). The bucketing strategy is the
+only meaningful axis of variation; the aggregation itself does not differ.
+
+After this parent closes, those three files share one aggregation core.
+Bucketing remains the per-site concern (lap time-windows for segments,
+km distance-windows with fractional weights for km-splits, single bucket
+for dynamics). The aggregator does not own bucket discovery — it consumes
+already-bucketed input.
+
+## Owned user stories
+
+From the cycle PRD:
+
+- As a maintainer changing how a tier-aware metric is rolled up across a
+  Run, I edit the single split-aggregation primitive once and segments,
+  km-splits, and dynamics all benefit, so I do not edit three near-identical
+  row builders.
+
+A success-signal story from the cycle PRD also lands here:
+
+- Adding a new split-aggregated metric (hypothetically) takes editing one
+  file, and the same change shows up in segments, km-splits, and dynamics
+  consistently without further work.
+
+## Encounter statements affecting this scope
+
+- A maintainer opening any of `computations/segments.ts`,
+  `computations/km-splits.ts`, or `computations/dynamics.ts` first
+  encounters bucket construction (the part that is genuinely different)
+  and a single shared call into the aggregator — not a fourth restatement
+  of the Tier-2/Tier-3 averaging block.
+- A maintainer opening the engine's public exports first encounters the
+  aggregation primitive grouped under `Analysis output` (alongside
+  `Segment`, `Km Split`, `Quantify`), reflecting `ubiquitous-language.md`.
+- A maintainer adding a new aggregated field (e.g. a hypothetical Tier 3
+  metric) edits the aggregator and its capability gate once; segments,
+  km-splits, and dynamics pick up the new field through the shared shape.
+
+## Directional dependencies on other sub-PRDs
+
+- Upstream: parent #32 (closed) — named domain types are already in
+  `plan/types.ts`. No re-opening. Parent #35 (closed) — Plan walker is
+  not on this path; this primitive operates on `Run2MaxRecord[]`, not on
+  Plan trees.
+- Downstream: the engine/presentation-split parent issue consumes this
+  primitive's output shape unchanged — formatters render `SegmentRow[]`,
+  `KmSplitRow[]`, and `DynamicsSummary` exactly as today, but those
+  shapes will be produced by one path. The helper-consolidation parent
+  may further fold `getDistance(record)` into a single home; the
+  aggregator parent does not own that consolidation but flags any
+  duplication it can no longer justify.
+- Sideways: no behaviour change. `quantify` output for fixtures stays
+  byte-identical. The cycle PRD's success metric ("the three current
+  row-builder paths reach one shared primitive with bucketing as the
+  only varying dimension") is the verification target.
+
+## Domain language
+
+The aggregator's input ("a bucket of records, optionally weighted") and
+its output ("the aggregated row for that bucket") map to **Segment**
+and **Km Split** as already defined in `ubiquitous-language.md`.
+**DynamicsSummary** is the whole-Run aggregation of the same shape — it
+is a single-bucket case of the same primitive.
+
+No new public-facing domain term is introduced. Internal type names like
+`AggregationInput` or `WeightedSlice` may emerge during implementation;
+those stay internal to the aggregator module unless they leak into a
+glossary-relevant seam, in which case `sdp-domain-validate` runs before
+the sub-issue closes.
+
+The cycle PRD's `MUST RESOLVE` open question — "what is the shape of the
+unified split-aggregator parameter — a `bucketBy` strategy function
+returning bucket keys, or a pre-bucketed `Slice[]` input the aggregator
+just reduces over?" — is decided in this sub-PRD's accompanying
+sub-issue via design-it-twice. Pre-resolution preference (recorded so
+the design-it-twice can challenge it): **pre-bucketed input**, because
+the three call sites' bucketing logic is the part that is genuinely
+different and is already deep where it lives. Folding bucket discovery
+into the aggregator widens its surface to absorb three unrelated
+strategies; folding aggregation out keeps each call site shallow only
+where it is naturally shallow.

--- a/context/cycles/01-deepen-engine/prd.md
+++ b/context/cycles/01-deepen-engine/prd.md
@@ -173,11 +173,10 @@ documented `TS2589` workaround. The CLI shrinks to a thin shell on top.
   #32), and `parsePlan` in `plan/schema.ts` returns the named `Plan`. This
   removed the public inferred-type chain while keeping schema/runtime
   validation in `schema.ts`.
-- `MUST RESOLVE`: What is the shape of the unified split-aggregator
-  parameter — a `bucketBy` strategy function returning bucket keys, or a
-  pre-bucketed `Slice[]` input the aggregator just reduces over? Affects
-  whether segments and km-splits share more than just row construction.
-  Decided in the split-aggregator sub-PRD.
+- `RESOLVED IN IMPLEMENTATION`: The unified split-aggregator parameter uses
+  pre-bucketed input (`aggregateBucket(bucket, config)`) rather than a
+  `bucketBy` strategy surface. Decision captured during parent issue #38 /
+  sub-issue #39 and recorded in ADR 0003.
 - `RESOLVE THROUGH IMPLEMENTATION`: Final shape of the engine's public
   export grouping. Target shape will emerge as parent issues land; the
   `index.ts` is rewritten last, once all internal seams settle.

--- a/packages/engine/src/computations/aggregate.test.ts
+++ b/packages/engine/src/computations/aggregate.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type { DataCapabilities, Run2MaxRecord } from "../types.js";
+import { aggregateBucket } from "./aggregate.js";
+
+function rec(overrides: Partial<Run2MaxRecord> = {}): Run2MaxRecord {
+  return {
+    timestamp: new Date(),
+    power: 220,
+    heartRate: 140,
+    cadence: 84,
+    ...overrides,
+  } as Run2MaxRecord;
+}
+
+const TIER1_ONLY: DataCapabilities = {
+  hasRunningDynamics: false,
+  hasStrydEnhanced: false,
+};
+
+const TIER2_ONLY: DataCapabilities = {
+  hasRunningDynamics: true,
+  hasStrydEnhanced: false,
+};
+
+const ALL_TIERS: DataCapabilities = {
+  hasRunningDynamics: true,
+  hasStrydEnhanced: true,
+};
+
+describe("aggregateBucket", () => {
+  it("computes Tier 1 arithmetic means and null-gates Tier 2/Tier 3", () => {
+    const result = aggregateBucket(
+      [
+        { record: rec({ power: 200, heartRate: 130, cadence: 80 }) },
+        { record: rec({ power: 240, heartRate: 150, cadence: 88 }) },
+      ],
+      { capabilities: TIER1_ONLY },
+    );
+
+    expect(result.avgPower).toBe(220);
+    expect(result.avgHeartRate).toBe(140);
+    expect(result.avgCadence).toBe(84);
+    expect(result.zone).toBeNull();
+    expect(result.avgStanceTime).toBeNull();
+    expect(result.avgFormPower).toBeNull();
+    expect(result.verticalRatio).toBeNull();
+    expect(result.formPowerRatio).toBeNull();
+  });
+
+  it("keeps Tier 2 fields null when capability is on but records lack values", () => {
+    const result = aggregateBucket(
+      [{ record: rec() }, { record: rec() }],
+      { capabilities: TIER2_ONLY },
+    );
+
+    expect(result.avgStanceTime).toBeNull();
+    expect(result.avgStanceTimeBalance).toBeNull();
+    expect(result.avgStepLength).toBeNull();
+    expect(result.avgVerticalOscillation).toBeNull();
+  });
+
+  it("computes Tier 2 and Tier 3 fields with ratio-of-means derived metrics", () => {
+    const result = aggregateBucket(
+      [
+        {
+          record: rec({
+            power: 200,
+            formPower: 50,
+            airPower: 10,
+            stanceTime: 330,
+            stanceTimeBalance: 50.1,
+            stepLength: 800,
+            verticalOscillation: 40,
+          }),
+        },
+        {
+          record: rec({
+            power: 300,
+            formPower: 90,
+            airPower: 14,
+            stanceTime: 370,
+            stanceTimeBalance: 49.9,
+            stepLength: 1000,
+            verticalOscillation: 60,
+          }),
+        },
+      ],
+      { capabilities: ALL_TIERS },
+    );
+
+    expect(result.avgPower).toBe(250);
+    expect(result.avgFormPower).toBe(70);
+    expect(result.avgAirPower).toBe(12);
+    expect(result.avgStanceTime).toBe(350);
+    expect(result.avgStepLength).toBe(900);
+    expect(result.avgVerticalOscillation).toBe(50);
+    expect(result.verticalRatio).toBeCloseTo((50 / 900) * 100);
+    expect(result.formPowerRatio).toBeCloseTo(70 / 250);
+  });
+
+  it("uses weighted means and per-field null handling", () => {
+    const result = aggregateBucket(
+      [
+        { record: rec({ power: 100, cadence: 80, stepLength: 800 }), weight: 0.5 },
+        { record: rec({ power: 300, cadence: null as unknown as number, stepLength: null as unknown as number }), weight: 0.5 },
+        { record: rec({ power: 500, cadence: 100, stepLength: 1000 }), weight: 1 },
+      ],
+      { capabilities: TIER2_ONLY },
+    );
+
+    expect(result.avgPower).toBeCloseTo((100 * 0.5 + 300 * 0.5 + 500 * 1) / 2);
+    expect(result.avgCadence).toBeCloseTo((80 * 0.5 + 100 * 1) / 1.5);
+    expect(result.avgStepLength).toBeCloseTo((800 * 0.5 + 1000 * 1) / 1.5);
+  });
+
+  it("returns all-null for empty bucket", () => {
+    const result = aggregateBucket([], { capabilities: ALL_TIERS });
+    expect(result).toEqual({
+      avgPower: null,
+      zone: null,
+      avgHeartRate: null,
+      avgCadence: null,
+      avgStanceTime: null,
+      avgStanceTimeBalance: null,
+      avgStepLength: null,
+      avgVerticalOscillation: null,
+      avgFormPower: null,
+      avgAirPower: null,
+      verticalRatio: null,
+      formPowerRatio: null,
+    });
+  });
+
+  it("treats undefined weight as 1", () => {
+    const result = aggregateBucket(
+      [
+        { record: rec({ power: 200 }) },
+        { record: rec({ power: 400 }), weight: undefined },
+      ],
+      { capabilities: TIER1_ONLY },
+    );
+    expect(result.avgPower).toBe(300);
+  });
+});

--- a/packages/engine/src/computations/aggregate.ts
+++ b/packages/engine/src/computations/aggregate.ts
@@ -1,0 +1,105 @@
+import type {
+  Run2MaxRecord,
+  DataCapabilities,
+  ZoneConfig,
+} from "../types.js";
+import { classifyPowerZone } from "./zones.js";
+
+export interface WeightedRecord {
+  record: Run2MaxRecord;
+  weight?: number;
+}
+
+export interface AggregationConfig {
+  capabilities: DataCapabilities;
+  zones?: ZoneConfig[];
+}
+
+export interface AggregatedFields {
+  avgPower: number | null;
+  zone: string | null;
+  avgHeartRate: number | null;
+  avgCadence: number | null;
+  avgStanceTime: number | null;
+  avgStanceTimeBalance: number | null;
+  avgStepLength: number | null;
+  avgVerticalOscillation: number | null;
+  avgFormPower: number | null;
+  avgAirPower: number | null;
+  verticalRatio: number | null;
+  formPowerRatio: number | null;
+}
+
+function weightedAvg(
+  bucket: readonly WeightedRecord[],
+  accessor: (record: Run2MaxRecord) => number | null | undefined,
+): number | null {
+  let sum = 0;
+  let totalWeight = 0;
+
+  for (const { record, weight } of bucket) {
+    const value = accessor(record);
+    if (value == null) continue;
+    const effectiveWeight = weight ?? 1;
+    sum += value * effectiveWeight;
+    totalWeight += effectiveWeight;
+  }
+
+  return totalWeight === 0 ? null : sum / totalWeight;
+}
+
+export function aggregateBucket(
+  bucket: readonly WeightedRecord[],
+  config: AggregationConfig,
+): AggregatedFields {
+  const { capabilities, zones } = config;
+
+  const avgPower = weightedAvg(bucket, (r) => r.power ?? null);
+  const avgHeartRate = weightedAvg(bucket, (r) => r.heartRate ?? null);
+  const avgCadence = weightedAvg(bucket, (r) => r.cadence ?? null);
+
+  const avgStanceTime = capabilities.hasRunningDynamics
+    ? weightedAvg(bucket, (r) => r.stanceTime ?? null)
+    : null;
+  const avgStanceTimeBalance = capabilities.hasRunningDynamics
+    ? weightedAvg(bucket, (r) => r.stanceTimeBalance ?? null)
+    : null;
+  const avgStepLength = capabilities.hasRunningDynamics
+    ? weightedAvg(bucket, (r) => r.stepLength ?? null)
+    : null;
+  const avgVerticalOscillation = capabilities.hasRunningDynamics
+    ? weightedAvg(bucket, (r) => r.verticalOscillation ?? null)
+    : null;
+
+  const avgFormPower = capabilities.hasStrydEnhanced
+    ? weightedAvg(bucket, (r) => r.formPower ?? null)
+    : null;
+  const avgAirPower = capabilities.hasStrydEnhanced
+    ? weightedAvg(bucket, (r) => r.airPower ?? null)
+    : null;
+
+  const zone = avgPower != null && zones ? classifyPowerZone(avgPower, zones) : null;
+  const verticalRatio =
+    avgVerticalOscillation != null && avgStepLength != null && avgStepLength > 0
+      ? (avgVerticalOscillation / avgStepLength) * 100
+      : null;
+  const formPowerRatio =
+    avgFormPower != null && avgPower != null && avgPower > 0
+      ? avgFormPower / avgPower
+      : null;
+
+  return {
+    avgPower,
+    zone,
+    avgHeartRate,
+    avgCadence,
+    avgStanceTime,
+    avgStanceTimeBalance,
+    avgStepLength,
+    avgVerticalOscillation,
+    avgFormPower,
+    avgAirPower,
+    verticalRatio,
+    formPowerRatio,
+  };
+}

--- a/packages/engine/src/computations/dynamics.ts
+++ b/packages/engine/src/computations/dynamics.ts
@@ -1,5 +1,5 @@
 import type { Run2MaxRecord, DynamicsSummary, DataCapabilities } from "../types.js";
-import { avg } from "./utils.js";
+import { aggregateBucket } from "./aggregate.js";
 
 /**
  * Compute aggregated running dynamics summary.
@@ -13,35 +13,19 @@ export function computeDynamicsSummary(
     return null;
   }
 
-  // Tier 2
-  const avgStanceTime = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.stanceTime ?? null))
-    : null;
-  const avgStanceTimeBalance = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.stanceTimeBalance ?? null))
-    : null;
-  const avgStepLength = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.stepLength ?? null))
-    : null;
-  const avgVerticalOscillation = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.verticalOscillation ?? null))
-    : null;
-  const avgVerticalOscillationBalance = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.verticalOscillationBalance ?? null))
-    : null;
+  const aggregated = aggregateBucket(
+    records.map((record) => ({ record })),
+    { capabilities },
+  );
 
-  // Tier 3
-  const avgFormPower = capabilities.hasStrydEnhanced
-    ? avg(records.map((r) => r.formPower ?? null))
-    : null;
-  const avgAirPower = capabilities.hasStrydEnhanced
-    ? avg(records.map((r) => r.airPower ?? null))
+  const avgVerticalOscillationBalance = capabilities.hasRunningDynamics
+    ? average(records.map((r) => r.verticalOscillationBalance ?? null))
     : null;
   const avgLegSpringStiffness = capabilities.hasStrydEnhanced
-    ? avg(records.map((r) => r.legSpringStiffness ?? null))
+    ? average(records.map((r) => r.legSpringStiffness ?? null))
     : null;
   const avgLegSpringStiffnessBalance = capabilities.hasStrydEnhanced
-    ? avg(records.map((r) => r.legSpringStiffnessBalance ?? null))
+    ? average(records.map((r) => r.legSpringStiffnessBalance ?? null))
     : null;
 
   // Derived: form power ratio (compute from records where both exist)
@@ -77,16 +61,27 @@ export function computeDynamicsSummary(
   }
 
   return {
-    avgStanceTime,
-    avgStanceTimeBalance,
-    avgStepLength,
-    avgVerticalOscillation,
+    avgStanceTime: aggregated.avgStanceTime,
+    avgStanceTimeBalance: aggregated.avgStanceTimeBalance,
+    avgStepLength: aggregated.avgStepLength,
+    avgVerticalOscillation: aggregated.avgVerticalOscillation,
     avgVerticalOscillationBalance,
-    avgFormPower,
-    avgAirPower,
+    avgFormPower: aggregated.avgFormPower,
+    avgAirPower: aggregated.avgAirPower,
     avgLegSpringStiffness,
     avgLegSpringStiffnessBalance,
     avgFormPowerRatio,
     avgVerticalRatio,
   };
+}
+
+function average(values: readonly (number | null)[]): number | null {
+  let sum = 0;
+  let count = 0;
+  for (const value of values) {
+    if (value == null) continue;
+    sum += value;
+    count += 1;
+  }
+  return count === 0 ? null : sum / count;
 }

--- a/packages/engine/src/computations/km-splits.ts
+++ b/packages/engine/src/computations/km-splits.ts
@@ -4,8 +4,7 @@ import type {
   ZoneConfig,
   DataCapabilities,
 } from "../types.js";
-import { avg } from "./utils.js";
-import { classifyPowerZone } from "./zones.js";
+import { aggregateBucket, type WeightedRecord } from "./aggregate.js";
 import { computeSplitElevation, getAltitude } from "./elevation.js";
 
 const KM_IN_METERS = 1000;
@@ -15,15 +14,6 @@ const KM_IN_METERS = 1000;
  */
 function getDistance(record: Run2MaxRecord): number {
   return ((record.strydDistance ?? record.distance) as number | undefined) ?? 0;
-}
-
-/**
- * A weighted sample: a record's metric values contributing a fractional
- * time weight to a km bucket.
- */
-interface WeightedRecord {
-  record: Run2MaxRecord;
-  weight: number; // 0..1, fraction of a full time interval
 }
 
 /**
@@ -89,31 +79,13 @@ export function computeKmSplits(
     .map((bucket, i) => buildKmSplitRow(bucket, i + 1, zones, capabilities));
 }
 
-function weightedAvg(
-  bucket: WeightedRecord[],
-  accessor: (r: Run2MaxRecord) => number | null | undefined,
-): number | null {
-  let sum = 0;
-  let totalWeight = 0;
-
-  for (const { record, weight } of bucket) {
-    const value = accessor(record);
-    if (value != null) {
-      sum += value * weight;
-      totalWeight += weight;
-    }
-  }
-
-  return totalWeight === 0 ? null : sum / totalWeight;
-}
-
 function buildKmSplitRow(
   bucket: WeightedRecord[],
   km: number,
   zones: ZoneConfig[] | undefined,
   capabilities: DataCapabilities,
 ): KmSplitRow {
-  const totalWeight = bucket.reduce((sum, w) => sum + w.weight, 0);
+  const totalWeight = bucket.reduce((sum, w) => sum + (w.weight ?? 1), 0);
   const duration = totalWeight; // each full weight = 1 second
 
   // Distance for this split: sum of weighted distance deltas
@@ -124,44 +96,11 @@ function buildKmSplitRow(
   // For partial splits, use actual distance; for full splits, it should be ~1000m
   const actualDistance = distance > 0 ? distance : totalWeight;
 
-  const avgPower = weightedAvg(bucket, (r) => r.power ?? null);
-  const avgHeartRate = weightedAvg(bucket, (r) => r.heartRate ?? null);
-  const avgCadence = weightedAvg(bucket, (r) => r.cadence ?? null);
+  const aggregated = aggregateBucket(bucket, { capabilities, zones });
 
   const avgPace =
     actualDistance > 0 ? duration / (actualDistance / 1000) : null;
 
-  const zone =
-    avgPower != null && zones ? classifyPowerZone(avgPower, zones) : null;
-
-  // Tier 2
-  const avgStanceTime = capabilities.hasRunningDynamics
-    ? weightedAvg(bucket, (r) => r.stanceTime ?? null)
-    : null;
-  const avgStanceTimeBalance = capabilities.hasRunningDynamics
-    ? weightedAvg(bucket, (r) => r.stanceTimeBalance ?? null)
-    : null;
-  const avgStepLength = capabilities.hasRunningDynamics
-    ? weightedAvg(bucket, (r) => r.stepLength ?? null)
-    : null;
-  const avgVerticalOscillation = capabilities.hasRunningDynamics
-    ? weightedAvg(bucket, (r) => r.verticalOscillation ?? null)
-    : null;
-
-  // Derived: vertical ratio (Tier 2)
-  const verticalRatio =
-    avgVerticalOscillation != null && avgStepLength != null && avgStepLength > 0
-      ? (avgVerticalOscillation / avgStepLength) * 100
-      : null;
-
-  // Derived: form power ratio (Tier 3)
-  const avgFormPower = capabilities.hasStrydEnhanced
-    ? weightedAvg(bucket, (r) => r.formPower ?? null)
-    : null;
-  const formPowerRatio =
-    avgFormPower != null && avgPower != null && avgPower > 0
-      ? avgFormPower / avgPower
-      : null;
 
   // Elevation
   const bucketRecords = bucket.map((w) => w.record);
@@ -171,28 +110,24 @@ function buildKmSplitRow(
   const elevLoss = splitElev?.loss ?? null;
 
   // Tier 3: air power
-  const avgAirPower = capabilities.hasStrydEnhanced
-    ? weightedAvg(bucket, (r) => r.airPower ?? null)
-    : null;
-
   return {
     km,
     distance: actualDistance,
     duration,
-    avgPower,
-    zone,
+    avgPower: aggregated.avgPower,
+    zone: aggregated.zone,
     avgPace,
-    avgHeartRate,
-    avgCadence,
-    avgStanceTime,
-    avgStanceTimeBalance,
-    avgStepLength,
-    avgVerticalOscillation,
-    formPowerRatio,
-    verticalRatio,
+    avgHeartRate: aggregated.avgHeartRate,
+    avgCadence: aggregated.avgCadence,
+    avgStanceTime: aggregated.avgStanceTime,
+    avgStanceTimeBalance: aggregated.avgStanceTimeBalance,
+    avgStepLength: aggregated.avgStepLength,
+    avgVerticalOscillation: aggregated.avgVerticalOscillation,
+    formPowerRatio: aggregated.formPowerRatio,
+    verticalRatio: aggregated.verticalRatio,
     elevGain,
     elevLoss,
-    avgAirPower,
+    avgAirPower: aggregated.avgAirPower,
     windSpeed: null,
     windDirection: null,
     temperature: null,

--- a/packages/engine/src/computations/segments.ts
+++ b/packages/engine/src/computations/segments.ts
@@ -5,8 +5,7 @@ import type {
   ZoneConfig,
   DataCapabilities,
 } from "../types.js";
-import { avg } from "./utils.js";
-import { classifyPowerZone } from "./zones.js";
+import { aggregateBucket } from "./aggregate.js";
 import { computeSplitElevation, getAltitude } from "./elevation.js";
 
 /**
@@ -81,45 +80,13 @@ function buildSegmentRow(
   const lastDist = distances.findLast((d) => d != null) ?? 0;
   const distance = lastDist - firstDist;
   const duration = records.length; // 1 record = 1 time interval
-
-  const avgPower = avg(records.map((r) => r.power ?? null));
-  const avgHeartRate = avg(records.map((r) => r.heartRate ?? null));
-  const avgCadence = avg(records.map((r) => r.cadence ?? null));
+  const aggregated = aggregateBucket(
+    records.map((record) => ({ record })),
+    { capabilities, zones },
+  );
 
   const avgPace =
     distance > 0 ? duration / (distance / 1000) : null;
-
-  const zone =
-    avgPower != null && zones ? classifyPowerZone(avgPower, zones) : null;
-
-  // Tier 2
-  const avgStanceTime = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.stanceTime ?? null))
-    : null;
-  const avgStanceTimeBalance = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.stanceTimeBalance ?? null))
-    : null;
-  const avgStepLength = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.stepLength ?? null))
-    : null;
-  const avgVerticalOscillation = capabilities.hasRunningDynamics
-    ? avg(records.map((r) => r.verticalOscillation ?? null))
-    : null;
-
-  // Derived: vertical ratio (Tier 2)
-  const verticalRatio =
-    avgVerticalOscillation != null && avgStepLength != null && avgStepLength > 0
-      ? (avgVerticalOscillation / avgStepLength) * 100
-      : null;
-
-  // Derived: form power ratio (Tier 3)
-  const avgFormPower = capabilities.hasStrydEnhanced
-    ? avg(records.map((r) => r.formPower ?? null))
-    : null;
-  const formPowerRatio =
-    avgFormPower != null && avgPower != null && avgPower > 0
-      ? avgFormPower / avgPower
-      : null;
 
   // Elevation
   const hasAltitudeData = records.some((r) => getAltitude(r) !== null);
@@ -128,28 +95,24 @@ function buildSegmentRow(
   const elevLoss = splitElev?.loss ?? null;
 
   // Tier 3: air power
-  const avgAirPower = capabilities.hasStrydEnhanced
-    ? avg(records.map((r) => r.airPower ?? null))
-    : null;
-
   return {
     lapIndex,
     distance,
     duration,
-    avgPower,
-    zone,
+    avgPower: aggregated.avgPower,
+    zone: aggregated.zone,
     avgPace,
-    avgHeartRate,
-    avgCadence,
-    avgStanceTime,
-    avgStanceTimeBalance,
-    avgStepLength,
-    avgVerticalOscillation,
-    formPowerRatio,
-    verticalRatio,
+    avgHeartRate: aggregated.avgHeartRate,
+    avgCadence: aggregated.avgCadence,
+    avgStanceTime: aggregated.avgStanceTime,
+    avgStanceTimeBalance: aggregated.avgStanceTimeBalance,
+    avgStepLength: aggregated.avgStepLength,
+    avgVerticalOscillation: aggregated.avgVerticalOscillation,
+    formPowerRatio: aggregated.formPowerRatio,
+    verticalRatio: aggregated.verticalRatio,
     elevGain,
     elevLoss,
-    avgAirPower,
+    avgAirPower: aggregated.avgAirPower,
     windSpeed: null,
     windDirection: null,
     temperature: null,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -47,6 +47,12 @@ export { classifyZone, classifyPowerZone, computeZoneDistribution } from "./comp
 export { computeSegments } from "./computations/segments.js";
 export { computeKmSplits } from "./computations/km-splits.js";
 export { computeDynamicsSummary } from "./computations/dynamics.js";
+export {
+  aggregateBucket,
+  type WeightedRecord,
+  type AggregationConfig,
+  type AggregatedFields,
+} from "./computations/aggregate.js";
 export { computeSummary } from "./computations/summary.js";
 export { detectAnomalies, applyAnomalyExclusions } from "./computations/anomalies.js";
 export { computeElevationProfile } from "./computations/elevation.js";


### PR DESCRIPTION

- Added a shared aggregation primitive in packages/engine/src/computations/aggregate.ts with public types (WeightedRecord, AggregationConfig, AggregatedFields) and aggregateBucket(...).
- Migrated dynamics, segments, and km-splits to consume the shared aggregator while preserving behavior-specific semantics (notably dynamics’ per-record ratio metrics).
- Added focused aggregator coverage in packages/engine/src/computations/aggregate.test.ts and kept existing computation tests green.
- Fixed a DTS/build issue by handling optional weights safely in km-splits (weight ?? 1) so engine package build succeeds.
- Exported the new aggregation surface from packages/engine/src/index.ts.
- Completed closure docs: added ADR 0003, updated context/adr/INDEX.md, added sub-issue and parent aar.md files for issue #38, and updated context/cycles/01-deepen-engine/prd.md to mark the split-aggregator shape decision as resolved.

Closes #38 , Closes #39 