### PR TITLE
feature: Adds utility consolidation

### DIFF
--- a/context/cycles/01-deepen-engine/issues/44-utility-consolidation/45-implement-utility-consolidation/sub-issue.md
+++ b/context/cycles/01-deepen-engine/issues/44-utility-consolidation/45-implement-utility-consolidation/sub-issue.md
@@ -1,0 +1,305 @@
+# Sub-Issue #45 — Implement utility consolidation
+
+## Description
+
+Consolidate the four duplicated helpers identified by parent #44 into one
+canonical home each, point every caller at the canonical home, and delete
+the duplicates. Reconcile `getDistance`'s return type to one honest
+signature.
+
+The four moves are mechanically similar but each has a small homing
+decision. This sub-issue is one vertical slice: one PR, one review window,
+one verification pass. If during implementation a homing decision turns
+out to be contentious enough to warrant its own decision space, lift it
+into a sibling sub-issue (`46-...`) rather than overloading this one.
+
+## Dependency classification
+
+All four utilities are **in-process** dependencies — pure TypeScript
+functions with no I/O, no external services, no runtime configuration.
+They are tested directly through the interface (the consumers' existing
+unit tests already cover their behaviour).
+
+No port/adapter is justified. No mock is needed. The only verification
+surfaces are:
+
+- `pnpm test` at the workspace root — proves behaviour preservation.
+- `pnpm --filter @run2max/engine build` — proves the DTS build still
+  succeeds (closure-flag from parent #38).
+- `grep` — proves uniqueness per helper name.
+
+## Interface design
+
+### `addDays(dateStr: string, days: number): string`
+
+Pure UTC ISO-date math. Body is byte-identical across all 7 sites:
+
+```typescript
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+```
+
+**Design-it-twice.**
+
+- **Alternative A — `packages/engine/src/plan/dates.ts`, exported from
+  engine's public surface.** Co-located with the only domain that uses
+  it (every current caller is plan-week math: building, syncing,
+  reconciling, statusing, associating, or quantify-time week-end
+  computation). Engine's public `index.ts` re-exports it so the three
+  CLI callers can import from `@run2max/engine`.
+- **Alternative B — `packages/engine/src/lib/dates.ts`, generic
+  infrastructure.** A new `lib/` directory for non-domain utilities.
+  Same export shape on the public surface, but the file lives outside
+  any domain folder.
+
+**Chosen: A.** Co-location matches the cycle PRD's stance that "domain
+language drives module shape" — `addDays` has no consumer outside plan
+date math today, so spinning up a `lib/` directory for one helper is
+speculative infrastructure. If a non-plan caller later needs ISO date
+math, the helper relocates then. **Rejection of B**: introduces a new
+top-level directory for a single function; over-organises before
+demand.
+
+The helper is added to the engine's public surface because three CLI
+files consume it across the package boundary. Final grouping in
+`index.ts` is the index-rewrite parent's call; this sub-issue adds the
+line under the existing Plan schema/types grouping.
+
+### `clonePlan(plan: Plan): Plan`
+
+Three-level nested spread. Body is byte-identical across both sites.
+
+**Design-it-twice.**
+
+- **Alternative A — `packages/engine/src/plan/clone.ts`, engine-internal.**
+  A small new file beside `plan/sync.ts` and `plan/adjust.ts`. Not
+  exported from `engine/index.ts` because no cross-package caller
+  exists.
+- **Alternative B — folded into `packages/engine/src/plan/types.ts`** as
+  a co-located helper next to the `Plan` interface. Saves one file but
+  mixes data definition with operation.
+
+**Chosen: A.** A small dedicated file keeps `plan/types.ts` purely
+declarative (parent #32's encounter statement: maintainers opening
+types files first encounter named interfaces, not operations). One
+extra file is cheap; type-file purity is valuable. **Rejection of B**:
+muddles the type module's encounter shape.
+
+### Case-transform helpers
+
+Two private functions repeated:
+
+```typescript
+function snakeToCamel(str: string): string { /* /(_[a-z])/ → uppercase */ }
+function transformKeys(value: unknown): unknown { /* recursive walk */ }
+```
+
+The CLI's `plan/create.ts` has the **inverse direction** —
+`camelToSnake` + `transformKeysToSnake` — used to emit YAML with
+snake_case keys. Bodies are mirror-symmetric.
+
+**Design-it-twice.**
+
+- **Alternative A — `packages/engine/src/plan/case-keys.ts`,
+  bidirectional, exported.** One module exports `snakeToCamel`,
+  `camelToSnake`, `transformKeysSnakeToCamel`,
+  `transformKeysCamelToSnake`. Both engine schema files import the
+  forward direction; the CLI's `plan/create.ts` imports the inverse.
+  Engine's public surface adds the four helpers (or the two
+  high-level `transformKeys*` functions only — implementation
+  detail).
+- **Alternative B — engine keeps an internal `case-keys.ts` (forward
+  only), CLI keeps its own private `camelToSnake` + wrapper.** No
+  cross-package coupling; the CLI's emit-side stays self-contained.
+  Eliminates the engine→CLI duplication of the forward direction
+  and the engine-side duplication between `plan/schema.ts` and
+  `config/schema.ts`, but leaves the CLI's inverse helper as a
+  separate single copy.
+
+**Chosen: A.** The two directions are symmetric mirrors of each
+other — keeping them in one module makes that symmetry visible and
+prevents future drift (e.g. one direction handles arrays correctly
+while the other doesn't). Exposing the helpers across the package
+boundary is a small public-surface cost; the alternative is keeping
+two near-identical case-transform modules in two packages, which is
+exactly the duplication this parent eliminates. **Rejection of B**:
+preserves a CLI-side copy of mirror-symmetric logic; future drift
+between the two directions is exactly the kind of bug this
+consolidation should prevent.
+
+The case helpers are infrastructure, not domain. Final placement in
+`engine/index.ts`'s grouping (under a possible "Infrastructure" or
+"Internal utilities" section) is the index-rewrite parent's call.
+This sub-issue adds the export lines; that parent groups them.
+
+### `getDistance(record: Run2MaxRecord): number | null`
+
+Reads `strydDistance` falling back to `distance`. Three callers
+(`segments`, `elevation`, `summary`) declare the return type as
+`number | null` and handle null at the call site. The fourth
+(`km-splits`) declares `number` and inlines `?? 0` in the helper
+itself.
+
+**Design-it-twice.**
+
+- **Alternative A — canonical signature is `number | null`,
+  km-splits inlines `?? 0` at its call sites.** Preserves the more
+  honest type; matches 3 of the 4 existing callers; lets each caller
+  decide whether null means "missing data" or "treat as zero".
+- **Alternative B — canonical signature is `number`, helper applies
+  `?? 0` internally.** Simpler at call sites but loses the
+  null-vs-zero distinction. Segments would need a separate
+  null-detection helper for its `distances.map(getDistance)` use
+  case (line 78 of `segments.ts`), which currently relies on the
+  `null` value to detect missing-distance records.
+
+**Chosen: A.** Forcing the signature to `number` would silently
+convert "no recorded distance" into "distance is zero metres" for
+the three callers that currently distinguish them. That is a
+behaviour change disguised as a refactor. The `?? 0` at km-splits'
+two call sites (lines 34–35 of `km-splits.ts`) is a one-line edit
+per site. **Rejection of B**: trades one inlined coalescer for
+silent null-coercion in three downstream computations.
+
+Home: extend `packages/engine/src/computations/utils.ts` with
+`getDistance`. That file already holds shared record-helper math
+(`avg`, `rollingWindowPeak`). No new file needed.
+
+## Acceptance criteria
+
+- `grep -rn "function addDays" packages/` returns exactly one hit.
+- `grep -rn "function clonePlan" packages/` returns exactly one hit.
+- `grep -rn "function snakeToCamel\|function camelToSnake" packages/`
+  returns at most one hit per name (one if the helpers are factored
+  out separately, zero if they live only as inline arrow expressions
+  inside `transformKeysSnakeToCamel` / `transformKeysCamelToSnake`).
+- `grep -rn "function transformKeys" packages/` returns at most two
+  hits — one for the snake-to-camel walker, one for the inverse —
+  both in the same module.
+- `grep -rn "function getDistance" packages/` returns exactly one hit
+  in `packages/engine/src/computations/utils.ts`.
+- All 7 `addDays` callers import from
+  `@run2max/engine` (CLI sites) or `./dates.js` / `./plan/dates.js`
+  (engine sites, depending on file location).
+- Both `clonePlan` callers import from `./clone.js`.
+- The three case-transform consumer sites (`plan/schema.ts`,
+  `config/schema.ts`, `cli/commands/plan/create.ts`) import from the
+  consolidated module.
+- The four `getDistance` consumer sites (`segments`, `km-splits`,
+  `elevation`, `summary`) import from `./utils.js` (relative within
+  `computations/`).
+- `km-splits.ts` lines 34–35 are updated to apply `?? 0` at the call
+  site, restoring the original `number` semantics that file relies
+  on.
+- `pnpm test` at the workspace root: green.
+- `pnpm --filter @run2max/engine build`: green (DTS build included).
+- `engine/index.ts` adds at most these public exports:
+  `addDays` (cross-package consumer in CLI), and the case-transform
+  helpers (cross-package consumer in CLI's `plan/create.ts`).
+  `clonePlan` and `getDistance` are not added to the public surface.
+- TypeScript strict mode stays on. No `TS2589`.
+- CLI behaviour is byte-identical against existing fixtures.
+
+## Proposed tests
+
+No new tests are written. The four utilities are pure helpers covered
+indirectly by the existing test suites for their consumers:
+
+- `addDays` is exercised by the plan-walking tests, the build/sync/
+  reconcile/status/associate test suites, and the CLI command tests
+  for `plan status`, `plan sync`, and `quantify`. If any current
+  caller's tests pass after the move, the helper move is correct.
+- `clonePlan` is exercised by `plan/sync.test.ts` and
+  `plan/adjust.test.ts` (immutability assertions). Both must pass
+  unmodified.
+- The case-transform helpers are exercised by every plan-fixture and
+  config-fixture test that round-trips snake_case YAML through
+  validation. The CLI's `plan/create.test.ts` exercises the inverse
+  direction.
+- `getDistance` is exercised by `computations/segments.test.ts`,
+  `km-splits.test.ts`, `elevation.test.ts`, and `summary.test.ts`.
+  The km-splits `?? 0` inlining is verified by km-splits' existing
+  expected-output fixtures.
+
+If the test suite passes and the grep checks return the expected
+counts, the consolidation is verified. Adding new tests for these
+helpers in isolation would test the test, not the system.
+
+## Affected artifacts
+
+**Created**:
+
+- `packages/engine/src/plan/dates.ts` (or `lib/dates.ts` per
+  design-it-twice — A chose `plan/dates.ts`).
+- `packages/engine/src/plan/clone.ts`.
+- `packages/engine/src/plan/case-keys.ts` (or `lib/case-keys.ts` —
+  A chose `plan/case-keys.ts` for symmetry with the `dates.ts`
+  decision; the engine-side schemas that consume it both live under
+  `plan/`-adjacent territory, and `config/schema.ts` already imports
+  from `plan/`-adjacent files).
+
+**Modified**:
+
+- `packages/engine/src/plan/associate.ts` — drop private `addDays`,
+  import from `./dates.js`.
+- `packages/engine/src/plan/build.ts` — drop private `addDays`,
+  import from `./dates.js`.
+- `packages/engine/src/plan/reconcile.ts` — drop private `addDays`,
+  import from `./dates.js`.
+- `packages/engine/src/plan/status.ts` — drop private `addDays`,
+  import from `./dates.js`.
+- `packages/engine/src/plan/sync.ts` — drop private `clonePlan`,
+  import from `./clone.js`.
+- `packages/engine/src/plan/adjust.ts` — drop private `clonePlan`,
+  import from `./clone.js`.
+- `packages/engine/src/plan/schema.ts` — drop private
+  `snakeToCamel` + `transformKeys`, import from `./case-keys.js`.
+- `packages/engine/src/config/schema.ts` — drop private
+  `snakeToCamel` + `transformKeys`, import from
+  `../plan/case-keys.js`.
+- `packages/engine/src/computations/utils.ts` — add `getDistance`.
+- `packages/engine/src/computations/segments.ts` — drop private
+  `getDistance`, import from `./utils.js`.
+- `packages/engine/src/computations/elevation.ts` — drop private
+  `getDistance`, import from `./utils.js`.
+- `packages/engine/src/computations/summary.ts` — drop private
+  `getDistance`, import from `./utils.js`.
+- `packages/engine/src/computations/km-splits.ts` — drop private
+  `getDistance`, import from `./utils.js`, inline `?? 0` at the two
+  call sites.
+- `packages/engine/src/index.ts` — add `export { addDays } from
+  "./plan/dates.js";` and `export { transformKeysSnakeToCamel,
+  transformKeysCamelToSnake } from "./plan/case-keys.js";` (final
+  grouping is the index-rewrite parent's call).
+- `packages/cli/src/commands/quantify.ts` — drop private `addDays`,
+  import from `@run2max/engine`.
+- `packages/cli/src/commands/plan/status.ts` — drop private
+  `addDays`, import from `@run2max/engine`.
+- `packages/cli/src/commands/plan/sync.ts` — drop private `addDays`,
+  import from `@run2max/engine`.
+- `packages/cli/src/commands/plan/create.ts` — drop private
+  `camelToSnake` + `transformKeysToSnake`, import from
+  `@run2max/engine`.
+
+**Deleted**: nothing as a file. All seven `addDays` private copies,
+both `clonePlan` private copies, all three forward
+`snakeToCamel` + `transformKeys` private copies, the CLI's
+`camelToSnake` + `transformKeysToSnake` private copies, and all four
+`getDistance` private copies are removed from their host files.
+
+## Dependencies
+
+- Upstream: parent #32 (closed) — `Plan` is `clonePlan`'s input type.
+- Upstream: parent #35 (closed) — `walkPlan` already absorbed the
+  fifth duplicate (`flattenWeeks`).
+- Upstream: parent #38 (closed) — `aggregateBucket` consumers are
+  the same files that hold `getDistance` duplicates; the bucketing
+  layer is unchanged.
+- Upstream: parent #41 (closed) — `addDays` was kept private to
+  `plan/status.ts` with an explicit hand-off to this parent.
+- Tooling: `pnpm test`, `pnpm --filter @run2max/engine build`, grep.
+- No external dependencies. No network. No filesystem state beyond
+  the source tree.

--- a/context/cycles/01-deepen-engine/issues/44-utility-consolidation/issue.md
+++ b/context/cycles/01-deepen-engine/issues/44-utility-consolidation/issue.md
@@ -1,0 +1,159 @@
+# Parent Issue #44 — Utility consolidation
+
+> Technical execution doc. Sub-issues live in sibling `XX-...` folders.
+
+## Acceptance criteria
+
+- **`addDays`**: exactly one definition exists in the workspace. Every
+  current caller (`packages/engine/src/plan/{associate,build,reconcile,status}.ts`,
+  `packages/cli/src/commands/{quantify,plan/status,plan/sync}.ts`) imports
+  it. The 7 private copies are deleted. Verified by
+  `grep -rn "function addDays" packages/` returning a single hit.
+- **`clonePlan`**: exactly one definition exists in
+  `packages/engine/src/plan/`. Both `plan/sync.ts` and `plan/adjust.ts`
+  import it. The 2 private copies are deleted. Verified by
+  `grep -rn "function clonePlan" packages/` returning a single hit. The
+  helper is engine-internal; it is **not** added to `engine/index.ts`'s
+  public surface unless a non-engine caller emerges (none today).
+- **`transformKeys` / `snakeToCamel` / `camelToSnake`**: exactly one
+  definition of each lives in the workspace. Both directions of the
+  recursive key-walk live in the same module. The three current schema /
+  emit sites (`packages/engine/src/plan/schema.ts`,
+  `packages/engine/src/config/schema.ts`,
+  `packages/cli/src/commands/plan/create.ts`) import from this module.
+  Verified by `grep -rn "function snakeToCamel\|function camelToSnake\|function transformKeys" packages/` returning at most one hit per name.
+- **`getDistance(record)`**: exactly one definition exists in
+  `packages/engine/src/computations/`. The canonical signature is
+  `(record: Run2MaxRecord) => number | null` — preserves the more honest
+  type used by 3 of the 4 callers. `computations/km-splits.ts` updates
+  its call sites to apply `?? 0` inline. The 4 private copies are
+  deleted. Verified by `grep -rn "function getDistance" packages/`
+  returning a single hit.
+- The engine's public surface in `packages/engine/src/index.ts` exports
+  `addDays` only if the CLI consumes it across the package boundary
+  (which it does today — three CLI files use it). All other consolidated
+  helpers (`clonePlan`, `snakeToCamel` / `camelToSnake` / their key-walk
+  variants, `getDistance`) stay engine-internal unless a cross-package
+  consumer exists. The index-rewrite parent (final cycle parent) owns
+  final grouping; this parent only adds the line and lets that parent
+  re-group.
+- The CLI's `transformKeysToSnake` is replaced by the canonical
+  camel-to-snake helper. If that helper is engine-internal,
+  `packages/cli/src/commands/plan/create.ts` either imports it from a
+  shared location *both* packages can reach, or keeps a CLI-thin wrapper
+  that calls the engine helper. The pre-resolution preference is to
+  expose the case helpers from engine if and only if the CLI is the only
+  external consumer; otherwise keep the CLI's local helper but have it
+  delegate to the engine's. The design-it-twice in sub-issue #45 settles
+  this.
+- All existing tests pass: `pnpm test` at the workspace root is green.
+- The engine package builds (DTS included):
+  `pnpm --filter @run2max/engine build` succeeds. This addresses the
+  closure-flag carried forward from parent #38 (DTS-build can fail even
+  when tests pass).
+- TypeScript strict mode stays on. `TS2589` does not regress.
+- CLI behaviour is byte-identical. `run2max plan status`,
+  `run2max plan status --full`, `run2max plan adjust`,
+  `run2max plan create`, `run2max plan sync`, and `run2max quantify`
+  produce the same output as before for the same fixtures. Verified by
+  running the existing CLI command tests without modification.
+- No new domain term is introduced. `ubiquitous-language.md` is
+  unchanged unless the design-it-twice surfaces a domain noun (it should
+  not).
+- Cycle PRD success metric #1 is satisfied: a single grep across
+  `packages/` shows zero remaining duplicates of `flattenWeeks`,
+  `clonePlan`, `addDays`, `transformKeys`, or `getDistance`.
+  (`flattenWeeks` is already absent — verified at parent open.)
+
+## Implementation approach
+
+1. In sub-issue #45, design-it-twice each utility's canonical home and
+   public-surface exposure. The four are independent design questions but
+   share the same shape (one canonical home, every caller imports it).
+   Record the chosen home and a one-sentence rejection rationale per
+   utility. The sub-PRD records pre-resolution preferences; the
+   design-it-twice may challenge them.
+2. Move `addDays` to its chosen home. Bodies are byte-identical across
+   all 7 sites; the move is mechanical. Update all 7 callers' imports.
+   Delete the 7 private copies. Run grep to confirm exactly one
+   definition remains.
+3. Move `clonePlan` to its chosen home (engine-internal). Update both
+   callers (`plan/sync.ts`, `plan/adjust.ts`). Delete the 2 private
+   copies.
+4. Move `snakeToCamel` and `camelToSnake` (and their `transformKeys` /
+   `transformKeysToSnake` recursive wrappers) to their chosen home.
+   Update the three schema/emit sites' imports. Delete the duplicates.
+5. Move `getDistance` to its chosen home (likely
+   `computations/utils.ts` since that file already holds shared
+   record-helper math like `avg` / `rollingWindowPeak`, or a sibling
+   `computations/record-helpers.ts` if `utils.ts` is reserved for
+   numeric helpers — sub-issue #45 picks). Standardise on the
+   `number | null` signature. Update km-splits' two call sites
+   (`getDistance(records[i])` and `getDistance(records[i - 1])`) to
+   apply `?? 0` inline. Delete the 4 private copies.
+6. Update `packages/engine/src/index.ts` only if a consolidated helper
+   needs to cross the package boundary. Today only `addDays` does
+   (three CLI files import it). Add the export under the existing Plan
+   schema/types/validation grouping (or wherever sub-issue #45
+   determines it sits) — final grouping is the index-rewrite parent's
+   call.
+7. Run `pnpm test` at the workspace root and confirm green.
+8. Run `pnpm --filter @run2max/engine build` and confirm the DTS build
+   succeeds — closure-flag check carried forward from parent #38.
+9. Run the grep checks listed under acceptance criteria. Each should
+   return exactly one hit for each helper name (zero for the deleted
+   `transformKeysToSnake` if it has been replaced by a wrapper, or one
+   if a thin wrapper survives).
+10. Record the verification in the parent close.
+
+If during implementation any of the four moves uncovers a real design
+fork — for example, if relocating `addDays` surfaces a debate over a
+generic `lib/dates.ts` vs. a domain-co-located `plan/dates.ts`, or if
+`getDistance`'s nullable reconciliation reveals a behaviour difference
+not captured by existing tests — that decision is lifted into a sibling
+sub-issue (`46-...`) rather than expanding sub-issue #45's scope.
+
+## Dependencies
+
+- Upstream: parent #32 (closed) — `Plan` is the input type for
+  `clonePlan`. No re-opening.
+- Upstream: parent #35 (closed) — eliminated `flattenWeeks`. This
+  parent inherits the "zero duplicates" success-metric language but
+  owns only the four remaining helpers.
+- Upstream: parent #38 (closed) — `aggregateBucket` consumes the
+  bucketing layer that uses `getDistance`. The bucketing layer is
+  untouched; only the helper signature is reconciled.
+- Upstream: parent #41 (closed) — `addDays` was kept private to
+  `plan/status.ts` during the engine/presentation split with the
+  explicit note that helper consolidation is this parent's scope.
+- External: `valibot` untouched. `vitest` continues to drive tests.
+- Tooling: `pnpm test` plus `pnpm --filter @run2max/engine build` for
+  repository-runnable verification, and grep to verify uniqueness.
+
+## Flags
+
+- This parent does not consolidate `flattenWeeks`. Parent #35 already
+  did. If a stray inline plan-flattening loop is discovered during
+  implementation, that is a parent #35 regression and should be flagged
+  separately.
+- The cycle PRD's `RESOLVE THROUGH IMPLEMENTATION` on the final
+  `index.ts` grouping stays open after this parent. This parent only
+  adds whatever export lines its consolidation forces; the final
+  ordering and section banners are the index-rewrite parent's call.
+- If sub-issue #45's design-it-twice for `transformKeys` surfaces a
+  cross-cutting decision (e.g. whether the engine should expose
+  case-conversion utilities at all, given they are infrastructure not
+  domain), `sdp-adr` runs at parent close. This is borderline — written
+  only if the chosen direction carries non-obvious rationale.
+- The engine deletion test (success signal from parent #41) does not
+  apply here. Helper consolidation is purely additive-then-subtractive
+  on the file graph; it does not introduce a deletable seam.
+- Once this parent closes, re-introducing a private `addDays`,
+  `clonePlan`, `transformKeys`, `snakeToCamel`, `camelToSnake`, or
+  `getDistance` anywhere in the workspace is a drift signal — flag it
+  in code review.
+- Single sub-issue #45 is sized to deliver the full parent scope. If
+  implementation reveals one of the four utility moves needs its own
+  decision space (e.g. the case helpers raise a public/private
+  question that splits the team), a sibling sub-issue is added under
+  this parent rather than overloading #45.

--- a/context/cycles/01-deepen-engine/issues/44-utility-consolidation/sub-prd.md
+++ b/context/cycles/01-deepen-engine/issues/44-utility-consolidation/sub-prd.md
@@ -1,0 +1,121 @@
+# Parent Issue #44 — Utility consolidation
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## Scope
+
+Collapse the four duplicated utility functions identified in the cycle PRD into
+a single canonical home each, and point every existing caller at the canonical
+home so no duplicates remain.
+
+Today, four utilities are copy-pasted across the workspace:
+
+- **`addDays(dateStr, days): string`** — pure UTC ISO-date math. **7 sites**:
+  `packages/engine/src/plan/{associate,build,reconcile,status}.ts`,
+  `packages/cli/src/commands/{quantify,plan/status,plan/sync}.ts`. All bodies
+  are byte-identical.
+- **`clonePlan(plan: Plan): Plan`** — three-level nested spread sufficient for
+  immutable updates. **2 sites**: `packages/engine/src/plan/{sync,adjust}.ts`.
+  Bodies are byte-identical.
+- **`transformKeys(value): unknown`** (snake-case → camel-case object-key
+  rewrite, applied before valibot validation). **2 forward sites**:
+  `packages/engine/src/{plan,config}/schema.ts`. The CLI's `plan/create.ts`
+  has the inverse `transformKeysToSnake` (camel → snake) used when emitting
+  YAML — same shape, opposite direction.
+- **`getDistance(record): number | null`** (or `number` in one site) — reads
+  `strydDistance` falling back to `distance`. **4 sites**:
+  `packages/engine/src/computations/{segments,elevation,summary,km-splits}.ts`.
+  The km-splits copy returns `number` with `?? 0`; the other three return
+  `number | null`. The four-callers signature reconciliation is part of this
+  parent's scope.
+
+This parent does not redesign any utility. It moves them into one home each
+and reconciles `getDistance`'s return type so the canonical signature is
+honest. After this parent closes:
+
+- `addDays` lives in one place and every caller imports it from there.
+- `clonePlan` lives in one place; `plan/sync.ts` and `plan/adjust.ts` both
+  import it.
+- `snakeToCamel` / `camelToSnake` (and the recursive key-walking versions)
+  live in one place and the three schema/emit sites import them.
+- `getDistance` lives in one place with one signature; km-splits inlines its
+  own `?? 0` at the call site if the canonical signature is `number | null`.
+
+User-facing behaviour stays byte-identical. CLI fixtures continue to pass.
+
+## Owned user stories
+
+From the cycle PRD:
+
+- As a maintainer adding a feature that needs to add days to an ISO date,
+  shallow-clone a Plan, transform snake/camel object keys, or read a record's
+  distance, I import one symbol from a known location, so I do not write the
+  fifth (or eighth) copy of the same helper.
+
+A success-signal story from the cycle PRD also lands here:
+
+- A maintainer running `grep -rn "function addDays\|function clonePlan\|function transformKeys\|function getDistance"` after the cycle finds **one
+  hit per utility**, not four to seven. (Cycle PRD success metric #1: "Zero
+  call sites duplicating `flattenWeeks`, `clonePlan`, `addDays`,
+  `transformKeys`, or `getDistance` after the cycle. Verified by grep.")
+
+`flattenWeeks` is already gone — it was consumed by `walkPlan` in parent #35.
+This parent owns the remaining four utilities listed in the metric.
+
+## Encounter statements affecting this scope
+
+- A maintainer opening a plan-touching module that needs to advance a date by
+  N days first encounters a single named import for `addDays` — not a
+  function literal at the bottom of the file.
+- A maintainer opening `packages/engine/src/plan/sync.ts` or `adjust.ts`
+  first encounters a single imported `clonePlan` rather than a private copy
+  of the three-level nested spread.
+- A maintainer opening a schema file (`plan/schema.ts`, `config/schema.ts`)
+  or a YAML emitter (`cli/commands/plan/create.ts`) first encounters one
+  named import for the case-transform helpers — not a private
+  `snakeToCamel` / `camelToSnake` copy.
+- A maintainer opening the four split-row computations
+  (`segments`, `km-splits`, `elevation`, `summary`) first encounters a
+  shared `getDistance` import with one signature, not four near-identical
+  private copies that disagree on whether the return type is nullable.
+
+## Directional dependencies on other sub-PRDs
+
+- Upstream: parent #32 (closed) — `Plan` is a stable named interface;
+  `clonePlan` consumes it. No re-opening.
+- Upstream: parent #35 (closed) — `walkPlan` already consumed `flattenWeeks`.
+  This parent does not touch the walker; the remaining flatten-style
+  duplication has already been eliminated.
+- Upstream: parent #38 (closed) — `aggregateBucket` is unrelated to record
+  helpers, but `getDistance` is used at the *bucketing* sites (segments,
+  km-splits) that feed `aggregateBucket`. The bucketing layer stays
+  unchanged; only the helper is consolidated.
+- Upstream: parent #41 (closed) — engine/presentation separation kept
+  `addDays` private to `plan/status.ts`. This parent relocates that local
+  copy along with the other six.
+- Downstream: the public-export rewrite parent (last in the cycle) regroups
+  `index.ts`. If any consolidated utility is exposed publicly (e.g.
+  `addDays` because the CLI imports it across the package boundary), the
+  index-rewrite parent decides whether it belongs under a Periodization
+  grouping, an infrastructure grouping, or stays internal-only via a
+  CLI-internal duplication that this parent declines to introduce. This
+  parent records its choice; the index-rewrite parent ratifies the
+  grouping.
+- Sideways: no behaviour change. `quantify` output and `plan` command output
+  for the existing fixtures stay byte-identical.
+
+## Domain language
+
+`ubiquitous-language.md` does not include `addDays`, `clonePlan`,
+`transformKeys`, or `getDistance` as glossary terms. They are internal
+infrastructure helpers — not domain concepts. This parent does not introduce
+any public-facing domain term.
+
+`sdp-domain-validate` is not required for this parent unless the
+design-it-twice in sub-issue #45 surfaces a candidate domain name (e.g. if
+co-locating helpers with a domain module suggests a new noun like "Plan
+Calendar" for the date helper). Pre-resolution preference: keep them as
+infrastructure under existing module-shape conventions; do not invent
+domain nouns for utility consolidation.

--- a/packages/cli/src/commands/plan/create.ts
+++ b/packages/cli/src/commands/plan/create.ts
@@ -10,25 +10,9 @@ import {
   validatePlan,
   reconcile,
   walkPlan,
+  transformKeysCamelToSnake,
   type Plan,
 } from "@run2max/engine";
-
-function camelToSnake(str: string): string {
-  return str.replace(/([A-Z])/g, (_, c: string) => `_${c.toLowerCase()}`);
-}
-
-function transformKeysToSnake(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(transformKeysToSnake);
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-        camelToSnake(k),
-        transformKeysToSnake(v),
-      ])
-    );
-  }
-  return value;
-}
 
 export default defineCommand({
   meta: {
@@ -189,7 +173,7 @@ export default defineCommand({
       }
     }
 
-    const snakePlan = transformKeysToSnake(plan);
+    const snakePlan = transformKeysCamelToSnake(plan);
     const yaml = stringifyYaml(snakePlan);
     await writeFile(filePath, yaml, "utf-8");
 

--- a/packages/cli/src/commands/plan/status.ts
+++ b/packages/cli/src/commands/plan/status.ts
@@ -8,6 +8,7 @@ import {
   formatFullView,
   scanBlockRuns,
   detectWeekDeviations,
+  addDays,
 } from "@run2max/engine";
 import type { DeviationReport } from "@run2max/engine";
 
@@ -91,13 +92,3 @@ export default defineCommand({
     console.log(output);
   },
 });
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T00:00:00Z");
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
-}

--- a/packages/cli/src/commands/plan/sync.ts
+++ b/packages/cli/src/commands/plan/sync.ts
@@ -14,6 +14,7 @@ import {
   REASON_CATEGORIES,
   scanBlockRuns,
   detectWeekDeviations,
+  addDays,
 } from "@run2max/engine";
 import type { Plan, TestingPeriod, MicrocycleConfig } from "@run2max/engine";
 import type { SyncData } from "@run2max/engine";
@@ -248,12 +249,6 @@ async function detectSuggestion(
   if (report.suggestDNF) return "DNF";
   if (report.suggestINC) return "INC";
   return undefined;
-}
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T00:00:00Z");
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/quantify.ts
+++ b/packages/cli/src/commands/quantify.ts
@@ -11,6 +11,7 @@ import {
   detectWeekDeviations,
   reportHasAnomalies,
   walkPlan,
+  addDays,
 } from "@run2max/engine";
 import type { OutputFormat, OutputProfileConfig, Plan, MicrocycleConfig } from "@run2max/engine";
 
@@ -272,16 +273,6 @@ export default defineCommand({
     }
   },
 });
-
-// ---------------------------------------------------------------------------
-// Previous-week unsynced warning
-// ---------------------------------------------------------------------------
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T00:00:00Z");
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
-}
 
 async function warnIfPreviousWeekUnsynced(
   plan: Plan,

--- a/packages/engine/src/computations/elevation.ts
+++ b/packages/engine/src/computations/elevation.ts
@@ -1,4 +1,5 @@
 import type { Run2MaxRecord, ElevationProfile } from "../types.js";
+import { getDistance } from "./utils.js";
 
 /**
  * Extract altitude from a record, preferring enhancedAltitude over altitude.
@@ -6,13 +7,6 @@ import type { Run2MaxRecord, ElevationProfile } from "../types.js";
  */
 export function getAltitude(record: Run2MaxRecord): number | null {
   return record.enhancedAltitude ?? record.altitude ?? null;
-}
-
-/**
- * Get accumulated distance from a record, preferring strydDistance.
- */
-function getDistance(record: Run2MaxRecord): number | null {
-  return (record.strydDistance ?? record.distance) as number | null;
 }
 
 /**

--- a/packages/engine/src/computations/km-splits.ts
+++ b/packages/engine/src/computations/km-splits.ts
@@ -6,15 +6,9 @@ import type {
 } from "../types.js";
 import { aggregateBucket, type WeightedRecord } from "./aggregate.js";
 import { computeSplitElevation, getAltitude } from "./elevation.js";
+import { getDistance } from "./utils.js";
 
 const KM_IN_METERS = 1000;
-
-/**
- * Get the distance value from a record, preferring strydDistance.
- */
-function getDistance(record: Run2MaxRecord): number {
-  return ((record.strydDistance ?? record.distance) as number | undefined) ?? 0;
-}
 
 /**
  * Slice records at 1km distance boundaries with interpolation.
@@ -31,8 +25,8 @@ export function computeKmSplits(
   let currentBoundary = KM_IN_METERS;
 
   for (let i = 0; i < records.length; i++) {
-    const dist = getDistance(records[i]);
-    const prevDist = i > 0 ? getDistance(records[i - 1]) : 0;
+    const dist = getDistance(records[i]) ?? 0;
+    const prevDist = i > 0 ? (getDistance(records[i - 1]) ?? 0) : 0;
 
     if (dist < currentBoundary) {
       // Record is fully within the current km bucket
@@ -89,8 +83,8 @@ function buildKmSplitRow(
   const duration = totalWeight; // each full weight = 1 second
 
   // Distance for this split: sum of weighted distance deltas
-  const firstDist = getDistance(bucket[0].record);
-  const lastDist = getDistance(bucket[bucket.length - 1].record);
+  const firstDist = getDistance(bucket[0].record) ?? 0;
+  const lastDist = getDistance(bucket[bucket.length - 1].record) ?? 0;
   const distance = lastDist - firstDist || totalWeight * (KM_IN_METERS / duration || 0);
 
   // For partial splits, use actual distance; for full splits, it should be ~1000m

--- a/packages/engine/src/computations/segments.ts
+++ b/packages/engine/src/computations/segments.ts
@@ -7,13 +7,7 @@ import type {
 } from "../types.js";
 import { aggregateBucket } from "./aggregate.js";
 import { computeSplitElevation, getAltitude } from "./elevation.js";
-
-/**
- * Get the distance value from a record, preferring strydDistance.
- */
-function getDistance(record: Run2MaxRecord): number | null {
-  return (record.strydDistance ?? record.distance) as number | null;
-}
+import { getDistance } from "./utils.js";
 
 /**
  * Convert a timestamp to epoch ms for comparison.

--- a/packages/engine/src/computations/summary.ts
+++ b/packages/engine/src/computations/summary.ts
@@ -5,16 +5,15 @@ import type {
   QuantifyOptions,
   Run2MaxConfig,
 } from "../types.js";
-import { avg, rollingWindowPeak, rollingWindowMin, computeNormalizedPower } from "./utils.js";
+import {
+  avg,
+  rollingWindowPeak,
+  rollingWindowMin,
+  computeNormalizedPower,
+  getDistance,
+} from "./utils.js";
 import { classifyPowerZone, classifyZone } from "./zones.js";
 import { computeElevationProfile } from "./elevation.js";
-
-/**
- * Get the distance value from a record, preferring strydDistance.
- */
-function getDistance(record: Run2MaxRecord): number | null {
-  return (record.strydDistance ?? record.distance) as number | null;
-}
 
 /**
  * Resolve LTHR from config: thresholds.lthr → calibration.lthr → null.

--- a/packages/engine/src/computations/utils.ts
+++ b/packages/engine/src/computations/utils.ts
@@ -1,3 +1,5 @@
+import type { Run2MaxRecord } from "../types.js";
+
 /**
  * Compute the arithmetic mean of numeric values, skipping null/undefined.
  * Returns null if no valid values exist.
@@ -12,6 +14,13 @@ export function avg(values: (number | null | undefined)[]): number | null {
     }
   }
   return count === 0 ? null : sum / count;
+}
+
+/**
+ * Get the distance value from a record, preferring strydDistance.
+ */
+export function getDistance(record: Run2MaxRecord): number | null {
+  return (record.strydDistance ?? record.distance) as number | null;
 }
 
 /**

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -1,25 +1,5 @@
 import * as v from "valibot";
-
-// ---------------------------------------------------------------------------
-// Snake_case → camelCase transform (applied before validation)
-// ---------------------------------------------------------------------------
-
-function snakeToCamel(str: string): string {
-  return str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
-}
-
-function transformKeys(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(transformKeys);
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-        snakeToCamel(k),
-        transformKeys(v),
-      ])
-    );
-  }
-  return value;
-}
+import { transformKeysSnakeToCamel } from "../plan/case-keys.js";
 
 // ---------------------------------------------------------------------------
 // Valibot schema
@@ -166,5 +146,5 @@ export type CustomConfig = v.InferOutput<typeof CustomSchema>;
 // ---------------------------------------------------------------------------
 
 export function parseConfig(raw: unknown): Run2MaxConfig {
-  return v.parse(Run2MaxConfigSchema, transformKeys(raw));
+  return v.parse(Run2MaxConfigSchema, transformKeysSnakeToCamel(raw));
 }

--- a/packages/engine/src/formatters/utils.ts
+++ b/packages/engine/src/formatters/utils.ts
@@ -258,19 +258,4 @@ export function padTable(headers: string[], rows: string[][]): string {
   return [renderRow(headers), separator, ...rows.map(renderRow)].join("\n");
 }
 
-// ---------------------------------------------------------------------------
-// camelCase → snake_case (recursive, for YAML output)
-// ---------------------------------------------------------------------------
-
-export function camelToSnake(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(camelToSnake);
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-        k.replace(/([A-Z])/g, "_$1").toLowerCase(),
-        camelToSnake(v),
-      ])
-    );
-  }
-  return value;
-}
+export { transformKeysCamelToSnake as camelToSnake } from "../plan/case-keys.js";

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { ENGINE_VERSION } from "./index.js";
+import { ENGINE_VERSION, addDays } from "./index.js";
 
 describe("engine", () => {
   it("exports a version string", () => {
     expect(ENGINE_VERSION).toBe("1.1.0");
+  });
+
+  it("exports addDays for cross-package plan date math", () => {
+    expect(addDays("2026-01-26", 7)).toBe("2026-02-02");
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -83,6 +83,7 @@ export type { Diagnostic } from "./plan/validate.js";
 export { loadPlan, loadUserTemplates, resolveTemplate } from "./plan/loader.js";
 export { buildPlanFromTemplate } from "./plan/build.js";
 export type { BuildPlanOptions } from "./plan/build.js";
+export { addDays } from "./plan/dates.js";
 export { reconcile } from "./plan/reconcile.js";
 export type { ReconcileOptions, ReconciliationResult, CompressionOption } from "./plan/reconcile.js";
 export { getPlanStatus } from "./plan/status.js";
@@ -97,6 +98,7 @@ export { walkPlan } from "./plan/walk.js";
 export type { WeekContext } from "./plan/walk.js";
 export { associateRun, scanBlockRuns, extractDisplayName } from "./plan/associate.js";
 export type { WeekAssociation, BlockRun } from "./plan/associate.js";
+export { transformKeysSnakeToCamel, transformKeysCamelToSnake } from "./plan/case-keys.js";
 
 // ---------------------------------------------------------------------------
 // Plan templates

--- a/packages/engine/src/plan/adjust.ts
+++ b/packages/engine/src/plan/adjust.ts
@@ -1,5 +1,6 @@
 import type { Plan } from "./types.js";
 import type { PlanTemplate } from "./templates/types.js";
+import { clonePlan } from "./clone.js";
 import { reconcile } from "./reconcile.js";
 import type { CompressionOption } from "./reconcile.js";
 import { walkPlan } from "./walk.js";
@@ -84,22 +85,6 @@ function extractFutureTemplate(
   }
 
   return { name: "future", description: "extracted future portion", mesocycles };
-}
-
-/**
- * Deep-clones a Plan (structural copy sufficient for immutable updates).
- */
-function clonePlan(plan: Plan): Plan {
-  return {
-    ...plan,
-    mesocycles: plan.mesocycles.map((meso) => ({
-      ...meso,
-      fractals: meso.fractals.map((fractal) => ({
-        ...fractal,
-        weeks: fractal.weeks.map((week) => ({ ...week })),
-      })),
-    })),
-  };
 }
 
 /**

--- a/packages/engine/src/plan/associate.ts
+++ b/packages/engine/src/plan/associate.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseFitBuffer, normalizeFFP } from "normalize-fit-file";
 import type { Plan } from "./types.js";
+import { addDays } from "./dates.js";
 import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
@@ -23,16 +24,6 @@ export interface BlockRun {
   path: string;
   displayName: string;
   date: Date;
-}
-
-// ---------------------------------------------------------------------------
-// Date helpers
-// ---------------------------------------------------------------------------
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T00:00:00Z");
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
 }
 
 /**

--- a/packages/engine/src/plan/build.ts
+++ b/packages/engine/src/plan/build.ts
@@ -1,5 +1,6 @@
 import type { PlanTemplate } from "./templates/types.js";
 import type { Plan } from "./types.js";
+import { addDays } from "./dates.js";
 
 export interface BuildPlanOptions {
   block: string;
@@ -19,12 +20,6 @@ const DAY_NUMBERS: Record<string, number> = {
   friday: 5,
   saturday: 6,
 };
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(`${dateStr}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
-}
 
 export function buildPlanFromTemplate(template: PlanTemplate, options: BuildPlanOptions): Plan {
   const weekStartDay = options.weekStart ?? "monday";

--- a/packages/engine/src/plan/case-keys.ts
+++ b/packages/engine/src/plan/case-keys.ts
@@ -1,0 +1,31 @@
+const snakeToCamelKey = (str: string): string =>
+  str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+
+const camelToSnakeKey = (str: string): string =>
+  str.replace(/([A-Z])/g, (_, c: string) => `_${c.toLowerCase()}`);
+
+export const transformKeysSnakeToCamel = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(transformKeysSnakeToCamel);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        snakeToCamelKey(k),
+        transformKeysSnakeToCamel(v),
+      ]),
+    );
+  }
+  return value;
+};
+
+export const transformKeysCamelToSnake = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(transformKeysCamelToSnake);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        camelToSnakeKey(k),
+        transformKeysCamelToSnake(v),
+      ]),
+    );
+  }
+  return value;
+};

--- a/packages/engine/src/plan/clone.ts
+++ b/packages/engine/src/plan/clone.ts
@@ -1,0 +1,14 @@
+import type { Plan } from "./types.js";
+
+export function clonePlan(plan: Plan): Plan {
+  return {
+    ...plan,
+    mesocycles: plan.mesocycles.map((meso) => ({
+      ...meso,
+      fractals: meso.fractals.map((fractal) => ({
+        ...fractal,
+        weeks: fractal.weeks.map((week) => ({ ...week })),
+      })),
+    })),
+  };
+}

--- a/packages/engine/src/plan/dates.ts
+++ b/packages/engine/src/plan/dates.ts
@@ -1,0 +1,5 @@
+export function addDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}

--- a/packages/engine/src/plan/reconcile.ts
+++ b/packages/engine/src/plan/reconcile.ts
@@ -1,5 +1,6 @@
 import type { PlanTemplate } from "./templates/types.js";
 import type { Plan } from "./types.js";
+import { addDays } from "./dates.js";
 
 export interface ReconcileOptions {
   template: PlanTemplate;
@@ -39,12 +40,6 @@ const DAY_NUMBERS: Record<string, number> = {
   friday: 5,
   saturday: 6,
 };
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(`${dateStr}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
-}
 
 function weekStartOf(dateStr: string, weekStartDay = "monday"): string {
   const d = new Date(`${dateStr}T00:00:00Z`);

--- a/packages/engine/src/plan/schema.ts
+++ b/packages/engine/src/plan/schema.ts
@@ -1,22 +1,6 @@
 import * as v from "valibot";
 import type { Plan } from "./types.js";
-
-function snakeToCamel(str: string): string {
-  return str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
-}
-
-function transformKeys(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(transformKeys);
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-        snakeToCamel(k),
-        transformKeys(v),
-      ])
-    );
-  }
-  return value;
-}
+import { transformKeysSnakeToCamel } from "./case-keys.js";
 
 export const PLANNED_WEEK_TYPES = ["L", "LL", "LLL", "D", "Ta", "Tb", "P", "R", "N"] as const;
 export const EXECUTED_ONLY_TYPES = ["INC", "DNF"] as const;
@@ -69,5 +53,5 @@ export const PlanSchema = v.object({
 });
 
 export function parsePlan(raw: unknown): Plan {
-  return v.parse(PlanSchema, transformKeys(raw));
+  return v.parse(PlanSchema, transformKeysSnakeToCamel(raw));
 }

--- a/packages/engine/src/plan/status.ts
+++ b/packages/engine/src/plan/status.ts
@@ -1,5 +1,6 @@
 import type { Plan } from "./types.js";
 import type { DeviationReport } from "./detect.js";
+import { addDays } from "./dates.js";
 import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
@@ -48,16 +49,6 @@ export interface PlanStatus {
   nextMilestones: NextMilestone[];
   unsyncedPastWeeks: WeekStatusEntry[];
   weeks: WeekStatusEntry[];
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + "T00:00:00Z");
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/plan/sync.ts
+++ b/packages/engine/src/plan/sync.ts
@@ -1,4 +1,5 @@
 import type { Plan, TestingPeriod } from "./types.js";
+import { clonePlan } from "./clone.js";
 import { walkPlan } from "./walk.js";
 
 // ---------------------------------------------------------------------------
@@ -54,23 +55,6 @@ function findLastTestWeekInSequence(
   }
 
   return lastTestWi;
-}
-
-/**
- * Produces a deep-ish clone of the plan sufficient for immutable updates.
- * Clones the structural path down to a specific week.
- */
-function clonePlan(plan: Plan): Plan {
-  return {
-    ...plan,
-    mesocycles: plan.mesocycles.map((meso) => ({
-      ...meso,
-      fractals: meso.fractals.map((fractal) => ({
-        ...fractal,
-        weeks: fractal.weeks.map((week) => ({ ...week })),
-      })),
-    })),
-  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Consolidated helpers:
  - addDays → packages/engine/src/plan/dates.ts (exported via engine index)
  - clonePlan → packages/engine/src/plan/clone.ts (engine-internal)
  - case transforms → packages/engine/src/plan/case-keys.ts (snake↔camel recursive transforms)
  - getDistance → packages/engine/src/computations/utils.ts with canonical number | null
- Repointed all engine + CLI call sites to canonical imports, including CLI plan/create and formatter snake-case conversion to avoid drift.
- Updated km-splits to preserve number behavior by applying ?? 0 at call sites.
- Added index-surface exports required for cross-package consumers (addDays, transform helpers).


Close #44 , Close #45 