### PR TITLE
Prescribed Run model and notation 

### DIFF
--- a/context/adr/0005-prescribed-runs-store-expanded-steps.md
+++ b/context/adr/0005-prescribed-runs-store-expanded-steps.md
@@ -1,0 +1,24 @@
+# Prescribed Runs store expanded steps on the parsed Plan
+
+_Made during: 02-run-prescriptions-and-comparisons / parent issue #53 /
+sub-issue #54_ _Scope: product_ _Status: accepted_
+
+When parsing a Plan, `parsePlan` eagerly parses Prescription Notation inside
+Week-level `prescribed_runs` and stores the expanded, ordered `PrescribedStep[]`
+on each `PrescribedRun`. This keeps downstream association/comparison code
+working with stable domain data (steps + targets) instead of re-parsing notation
+at each call site.
+
+## Considered Options
+
+- Store only authored metadata on the Plan and require downstream consumers to
+  call the notation parser lazily.
+- Store a richer parser AST on the Plan in addition to the expanded steps.
+
+## Consequences
+
+- Plan parsing fails fast when a `prescribed_runs` entry contains invalid
+  notation.
+- Downstream parents do not need to repeat parser invocation or error handling.
+- Prescription grammar internals remain out of the public Plan shape (only
+  domain steps/targets are stored).

--- a/context/adr/INDEX.md
+++ b/context/adr/INDEX.md
@@ -6,3 +6,4 @@
 | 0002 | Plan-family interfaces live in `plan/types.ts` | product | accepted | Keep public Plan domain types as named interfaces in a standalone module, separate from parser/schema definitions. |
 | 0003 | Split aggregation uses pre-bucketed input | product | accepted | Standardize shared aggregation on `aggregateBucket(bucket, config)` while keeping bucket discovery in each computation module. |
 | 0004 | Plan-status formatters live in engine formatters and remain engine-public | product | accepted | Keep plan-status rendering in `formatters/plan.ts` while continuing engine-surface exports for formatter consumers. |
+| 0005 | Prescribed Runs store expanded steps on the parsed Plan | product | accepted | Parse Prescription Notation during Plan parsing and store expanded ordered `PrescribedStep[]` on each `PrescribedRun` to avoid downstream reparsing. |

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/54-implement-prescribed-run-model/aar.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/54-implement-prescribed-run-model/aar.md
@@ -1,0 +1,10 @@
+1. Did it go as planned? Yes -- the Week-level `prescribed_runs` shape, notation
+   parser, and step expansion landed together with passing tests.
+2. What changed from the sub-issue plan: No meaningful scope change;
+   implementation matched Alternative A (parsed Plan owns authored metadata plus
+   expanded steps).
+3. Carry-forward -- flags to write in the parent, divergence to note for future
+   siblings, notes for the parent issue's AAR: No flags written. Downstream
+   parents should treat `PrescribedRun.steps` as the canonical parsed
+   representation and use `PrescribedRun.prescription` only for
+   display/diagnostics.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/54-implement-prescribed-run-model/sub-issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/54-implement-prescribed-run-model/sub-issue.md
@@ -28,14 +28,14 @@ this sub-issue is planned.
 
 ## Dependency classification
 
-| Dependency | Category | Testing strategy |
-| --- | --- | --- |
-| TypeScript compiler | In-process | Test directly through existing package test/build commands. |
-| `vitest` | In-process | New parser and Plan schema tests run in the existing engine suite. |
-| `valibot` Plan parser | In-process | Extend existing schema tests; do not introduce a second runtime validation library. |
-| `transformKeysSnakeToCamel` | In-process | Test through a snake_case `prescribed_runs` fixture parsed by `parsePlan`. |
+| Dependency                            | Category   | Testing strategy                                                                                                                          |
+| ------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| TypeScript compiler                   | In-process | Test directly through existing package test/build commands.                                                                               |
+| `vitest`                              | In-process | New parser and Plan schema tests run in the existing engine suite.                                                                        |
+| `valibot` Plan parser                 | In-process | Extend existing schema tests; do not introduce a second runtime validation library.                                                       |
+| `transformKeysSnakeToCamel`           | In-process | Test through a snake_case `prescribed_runs` fixture parsed by `parsePlan`.                                                                |
 | Named Plan interfaces from parent #32 | In-process | Extend `Week` with optional `prescribedRuns`; type drift is covered by existing type-level Plan tests plus new type assertions if needed. |
-| Plan walker from parent #35 | In-process | No direct implementation dependency in this sub-issue; downstream association work will use it to find Week-level Prescribed Runs. |
+| Plan walker from parent #35           | In-process | No direct implementation dependency in this sub-issue; downstream association work will use it to find Week-level Prescribed Runs.        |
 
 No remote, collaborator-owned, true external, or irreplaceable dependencies. No
 port is required because parsing and expansion are pure in-process data
@@ -139,8 +139,8 @@ if (firstRun) {
 
 **Alternative B -- Authored Plan shape only, parser called lazily by consumers**
 
-`parsePlan` accepts and returns only authored Prescribed Run metadata. Downstream
-parents call the parser when they need steps.
+`parsePlan` accepts and returns only authored Prescribed Run metadata.
+Downstream parents call the parser when they need steps.
 
 ```ts
 // packages/engine/src/plan/types.ts
@@ -178,13 +178,19 @@ return compareSegmentsToSteps(segments, parsed.steps);
 
 **Alternative C -- Rich AST plus expanded steps for strongest parser encounter**
 
-The parser returns both a syntax tree and flattened steps. The parsed Plan stores
-the rich result so future diagnostics and tooling can point to nested group
-structure.
+The parser returns both a syntax tree and flattened steps. The parsed Plan
+stores the rich result so future diagnostics and tooling can point to nested
+group structure.
 
 ```ts
 export type PrescriptionNode =
-  | { kind: "step"; source: string; target: PrescribedStepTarget; intensityLabel?: string; targetRange?: TargetRange }
+  | {
+      kind: "step";
+      source: string;
+      target: PrescribedStepTarget;
+      intensityLabel?: string;
+      targetRange?: TargetRange;
+    }
   | { kind: "sequence"; nodes: PrescriptionNode[] }
   | { kind: "repeat"; count: number; pattern: PrescriptionNode[] };
 
@@ -201,7 +207,9 @@ export interface PrescribedRun {
   parsedPrescription: ParsedPrescription;
 }
 
-export function parsePrescriptionNotation(input: string):
+export function parsePrescriptionNotation(
+  input: string,
+):
   | { ok: true; value: ParsedPrescription }
   | { ok: false; diagnostics: PrescriptionDiagnostic[] };
 ```
@@ -241,9 +249,9 @@ notation-specific helpers. Prescription domain interfaces live in
 `packages/engine/src/plan/types.ts` with `Week`, because Prescribed Runs are
 parsed Plan data rather than a derived comparison result.
 
-Rejected: putting the parser under `computations/`. One sentence:
-Prescription Notation belongs to Plan authoring, while `computations/` operates
-on captured Run data.
+Rejected: putting the parser under `computations/`. One sentence: Prescription
+Notation belongs to Plan authoring, while `computations/` operates on captured
+Run data.
 
 ### Public interface
 
@@ -289,7 +297,8 @@ Input YAML shape after snake-to-camel normalization:
 prescribed_runs:
   - local_date: "2026-05-12"
     label: Sub-threshold intervals
-    prescription: "1.6K @ E[205-234W] -> 4(3min @ SUB-T[260-280W]/1min @ E) -> 1.6K @ E"
+    prescription:
+      "1.6K @ E[205-234W] -> 4(3min @ SUB-T[260-280W]/1min @ E) -> 1.6K @ E"
     comparison_group: sub-t-3min
 ```
 
@@ -301,8 +310,8 @@ Invariants:
   parsed from the Plan after YAML decoding.
 - `PrescribedRun.steps` is ordered by `index`, starting at 1, and includes every
   expanded step from warmup through cooldown.
-- Repetition expansion preserves authored order. `4(A/B)` yields `A, B, A, B,
-  A, B, A, B` after any surrounding sequence steps.
+- Repetition expansion preserves authored order. `4(A/B)` yields
+  `A, B, A, B, A, B, A, B` after any surrounding sequence steps.
 - `TargetRange` v1 supports power ranges in watts only. Do not infer ranges from
   Zone labels.
 - `parsePrescriptionNotation(input)` accepts both `->` and `→` as separators;
@@ -333,8 +342,8 @@ Error modes:
   `comparisonGroup`, and expanded `steps`.
 - `parsePrescriptionNotation` parses simple distance steps, simple duration
   steps, ordered `->` sequences, ordered `→` sequences, repetition groups,
-  repeated work/recovery pairs separated by `/`, intensity labels after `@`,
-  and inline power Target Ranges.
+  repeated work/recovery pairs separated by `/`, intensity labels after `@`, and
+  inline power Target Ranges.
 - Repetition expansion produces stable 1-based step indexes and preserves order.
 - Invalid notation returns actionable diagnostics from the standalone parser and
   fails Plan parsing when the invalid notation is inside `prescribed_runs`.
@@ -346,7 +355,8 @@ Error modes:
 - No Run association, FIT lap comparison, output formatting, history lookup,
   database/cache, or zone-history lookup is introduced.
 - Repository-runnable verification commands pass at closure, including
-  `pnpm test` and any package build/DTS checks already defined in the repository.
+  `pnpm test` and any package build/DTS checks already defined in the
+  repository.
 
 ## Proposed tests
 
@@ -365,9 +375,10 @@ Error modes:
    and asserts `prescribedRuns[0].steps` is populated.
 3. **Existing Plan compatibility tests** -- existing fixtures without
    `prescribed_runs` continue to parse and validate unchanged.
-4. **Type-level drift guard** -- extend `packages/engine/src/plan/types.test-d.ts`
-   if needed so the named `Week` interface and `WeekSchema` output remain
-   assignable after `prescribedRuns` is added.
+4. **Type-level drift guard** -- extend
+   `packages/engine/src/plan/types.test-d.ts` if needed so the named `Week`
+   interface and `WeekSchema` output remain assignable after `prescribedRuns` is
+   added.
 5. **Public export smoke test** -- existing package export/type tests, or a new
    minimal import test if no export test exists, verify consumers can import the
    new types and `parsePrescriptionNotation` from `@run2max/engine`.
@@ -400,5 +411,5 @@ Error modes:
 - Parent #53 flags apply: accept both arrow spellings, do not infer Target
   Ranges from Zone labels, do not add reusable prescription templates, and do
   not add automatic interval detection.
-- If parser grammar decisions expand beyond the v1 constructs listed here,
-  pause and consider an ADR before implementing the wider grammar.
+- If parser grammar decisions expand beyond the v1 constructs listed here, pause
+  and consider an ADR before implementing the wider grammar.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/54-implement-prescribed-run-model/sub-issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/54-implement-prescribed-run-model/sub-issue.md
@@ -1,0 +1,404 @@
+# Sub-Issue #54 -- Implement the Prescribed Run model and notation parser
+
+Vertical slice for parent issue #53. Delivers the full parent scope as a single
+Plan/prescription foundation: add optional Week-level `prescribed_runs`, expose
+named Prescribed Run and Prescribed Step types, parse v1 Prescription Notation,
+and expand notation into ordered steps for downstream association and comparison
+parents.
+
+## Description
+
+Add the authored Prescribed Run shape to parsed Plans without changing
+`schemaVersion: 1`. A Week may now contain `prescribed_runs`, each with a local
+date, label, authored Prescription Notation, optional Comparison Group, and an
+expanded ordered Prescribed Step sequence derived from that notation.
+
+The parser covers the v1 grammar from parent #53: ordered steps separated by
+`->` or `→`, repetition groups such as `4(...)`, `/` between repeated
+work/recovery steps, distance targets such as `1.6K`, duration targets such as
+`3min`, intensity labels after `@`, and inline Target Ranges such as
+`[205-234W]`. The implementation stops at structured Plan/prescription data. It
+does not associate a captured Run to a Prescribed Run, inspect FIT laps, render
+prescription-comparison output, or read history artifacts.
+
+The scope is a vertical slice. If implementation reveals the parser and Plan
+schema change cannot land safely together, split the parser into a sibling
+sub-issue and leave this sub-issue as the Plan type/schema slice. Today, only
+this sub-issue is planned.
+
+## Dependency classification
+
+| Dependency | Category | Testing strategy |
+| --- | --- | --- |
+| TypeScript compiler | In-process | Test directly through existing package test/build commands. |
+| `vitest` | In-process | New parser and Plan schema tests run in the existing engine suite. |
+| `valibot` Plan parser | In-process | Extend existing schema tests; do not introduce a second runtime validation library. |
+| `transformKeysSnakeToCamel` | In-process | Test through a snake_case `prescribed_runs` fixture parsed by `parsePlan`. |
+| Named Plan interfaces from parent #32 | In-process | Extend `Week` with optional `prescribedRuns`; type drift is covered by existing type-level Plan tests plus new type assertions if needed. |
+| Plan walker from parent #35 | In-process | No direct implementation dependency in this sub-issue; downstream association work will use it to find Week-level Prescribed Runs. |
+
+No remote, collaborator-owned, true external, or irreplaceable dependencies. No
+port is required because parsing and expansion are pure in-process data
+transformations with no second adapter.
+
+## Interface design
+
+The interface this sub-issue commits to is the Plan shape for Week-level
+Prescribed Runs, the structured Prescribed Step shape, and the parser entry
+point used by tests and downstream parents.
+
+### Design-it-twice
+
+**Alternative A -- Parsed Plan owns authored metadata plus expanded steps**
+
+`parsePlan` returns a `Plan` whose `Week.prescribedRuns` entries preserve the
+authored notation and also contain `steps`. The standalone parser is exported so
+parser tests and future tooling can parse notation without loading a whole Plan.
+
+```ts
+// packages/engine/src/plan/types.ts
+export interface TargetRange {
+  metric: "power";
+  min: number;
+  max: number;
+  unit: "W";
+}
+
+export type PrescribedStepTarget =
+  | { kind: "distance"; value: number; unit: "km" }
+  | { kind: "duration"; value: number; unit: "seconds" };
+
+export interface PrescribedStep {
+  index: number;
+  target: PrescribedStepTarget;
+  intensityLabel?: string;
+  targetRange?: TargetRange;
+  source: string;
+}
+
+export interface PrescribedRun {
+  localDate: string;
+  label: string;
+  prescription: string;
+  comparisonGroup?: string;
+  steps: PrescribedStep[];
+}
+
+export interface Week {
+  planned: string;
+  start: string;
+  executed?: string;
+  reason?: string;
+  note?: string;
+  testingPeriod?: TestingPeriod;
+  prescribedRuns?: PrescribedRun[];
+}
+
+// packages/engine/src/plan/prescription.ts
+export interface PrescriptionDiagnostic {
+  code: "syntax" | "unsupported" | "missing_target_range";
+  message: string;
+  token?: string;
+  offset?: number;
+}
+
+export type PrescriptionParseResult =
+  | { ok: true; steps: PrescribedStep[] }
+  | { ok: false; diagnostics: PrescriptionDiagnostic[] };
+
+export interface PrescriptionParseOptions {
+  requireTargetRanges?: boolean;
+}
+
+export function parsePrescriptionNotation(
+  input: string,
+  options?: PrescriptionParseOptions,
+): PrescriptionParseResult;
+```
+
+Example caller shape:
+
+```ts
+const plan = parsePlan(rawPlan);
+const firstRun = plan.mesocycles[0]?.fractals[0]?.weeks[0]?.prescribedRuns?.[0];
+
+if (firstRun) {
+  for (const step of firstRun.steps) {
+    compareLater(step.index, step.target, step.targetRange);
+  }
+}
+```
+
+- Leverage: high -- every downstream parent consumes the same parsed structure
+  and avoids reparsing notation.
+- Locality: high -- Plan parsing owns the authored-to-structured boundary;
+  comparison and formatting modules receive domain data, not parser internals.
+- Testability: high -- parser tests exercise the standalone entry point, while
+  Plan schema tests prove `parsePlan` attaches steps to Week-level Prescribed
+  Runs.
+
+**Alternative B -- Authored Plan shape only, parser called lazily by consumers**
+
+`parsePlan` accepts and returns only authored Prescribed Run metadata. Downstream
+parents call the parser when they need steps.
+
+```ts
+// packages/engine/src/plan/types.ts
+export interface PrescribedRun {
+  localDate: string;
+  label: string;
+  prescription: string;
+  comparisonGroup?: string;
+}
+
+export interface Week {
+  planned: string;
+  start: string;
+  prescribedRuns?: PrescribedRun[];
+}
+
+// packages/engine/src/plan/prescription.ts
+export function parsePrescriptionNotation(
+  input: string,
+  options?: PrescriptionParseOptions,
+): PrescriptionParseResult;
+
+// Later comparison caller
+const parsed = parsePrescriptionNotation(prescribedRun.prescription);
+if (!parsed.ok) return unavailable(parsed.diagnostics);
+return compareSegmentsToSteps(segments, parsed.steps);
+```
+
+- Leverage: medium -- the Plan schema change is smaller, but every consumer that
+  needs steps must remember to parse first.
+- Locality: medium -- parser logic is local, but parser invocation leaks into
+  association, comparison, formatter, and history-adjacent code paths over time.
+- Testability: medium -- parser tests remain simple, but downstream tests must
+  repeatedly arrange parser success/failure before exercising their own logic.
+
+**Alternative C -- Rich AST plus expanded steps for strongest parser encounter**
+
+The parser returns both a syntax tree and flattened steps. The parsed Plan stores
+the rich result so future diagnostics and tooling can point to nested group
+structure.
+
+```ts
+export type PrescriptionNode =
+  | { kind: "step"; source: string; target: PrescribedStepTarget; intensityLabel?: string; targetRange?: TargetRange }
+  | { kind: "sequence"; nodes: PrescriptionNode[] }
+  | { kind: "repeat"; count: number; pattern: PrescriptionNode[] };
+
+export interface ParsedPrescription {
+  ast: PrescriptionNode;
+  steps: PrescribedStep[];
+}
+
+export interface PrescribedRun {
+  localDate: string;
+  label: string;
+  prescription: string;
+  comparisonGroup?: string;
+  parsedPrescription: ParsedPrescription;
+}
+
+export function parsePrescriptionNotation(input: string):
+  | { ok: true; value: ParsedPrescription }
+  | { ok: false; diagnostics: PrescriptionDiagnostic[] };
+```
+
+Example caller shape:
+
+```ts
+const nodes = prescribedRun.parsedPrescription.ast;
+const steps = prescribedRun.parsedPrescription.steps;
+renderFutureAuthoringHint(nodes);
+compareSegmentsToSteps(segments, steps);
+```
+
+- Leverage: low for this cycle -- downstream parents need ordered Prescribed
+  Steps, not a grammar tree.
+- Locality: medium -- parser internals become part of the public Plan shape,
+  making later grammar changes harder.
+- Testability: lower -- tests must assert tree structure in addition to the
+  domain output that comparison actually consumes.
+
+### Choice
+
+**A (parsed Plan owns authored metadata plus expanded steps).** It is the
+smallest public surface that prevents downstream parents from reparsing
+Prescription Notation while keeping parser internals out of the Plan shape.
+
+B is rejected in one sentence: it keeps the Plan shape smaller but makes every
+step-consuming parent repeat parser invocation and error handling.
+
+C is rejected in one sentence: exposing a grammar AST is stronger than the cycle
+needs and would make v1 notation internals harder to revise.
+
+### Module location
+
+`packages/engine/src/plan/prescription.ts` holds the parser, diagnostics, and
+notation-specific helpers. Prescription domain interfaces live in
+`packages/engine/src/plan/types.ts` with `Week`, because Prescribed Runs are
+parsed Plan data rather than a derived comparison result.
+
+Rejected: putting the parser under `computations/`. One sentence:
+Prescription Notation belongs to Plan authoring, while `computations/` operates
+on captured Run data.
+
+### Public interface
+
+```ts
+// packages/engine/src/plan/types.ts
+export interface TargetRange {
+  metric: "power";
+  min: number;
+  max: number;
+  unit: "W";
+}
+
+export type PrescribedStepTarget =
+  | { kind: "distance"; value: number; unit: "km" }
+  | { kind: "duration"; value: number; unit: "seconds" };
+
+export interface PrescribedStep {
+  index: number;
+  target: PrescribedStepTarget;
+  intensityLabel?: string;
+  targetRange?: TargetRange;
+  source: string;
+}
+
+export interface PrescribedRun {
+  localDate: string;
+  label: string;
+  prescription: string;
+  comparisonGroup?: string;
+  steps: PrescribedStep[];
+}
+
+// packages/engine/src/plan/prescription.ts
+export function parsePrescriptionNotation(
+  input: string,
+  options?: PrescriptionParseOptions,
+): PrescriptionParseResult;
+```
+
+Input YAML shape after snake-to-camel normalization:
+
+```yaml
+prescribed_runs:
+  - local_date: "2026-05-12"
+    label: Sub-threshold intervals
+    prescription: "1.6K @ E[205-234W] -> 4(3min @ SUB-T[260-280W]/1min @ E) -> 1.6K @ E"
+    comparison_group: sub-t-3min
+```
+
+Invariants:
+
+- `prescribedRuns` is optional. Omitted means the Week has no Prescribed Runs;
+  existing Plans stay valid.
+- `PrescribedRun.prescription` preserves the authored notation string exactly as
+  parsed from the Plan after YAML decoding.
+- `PrescribedRun.steps` is ordered by `index`, starting at 1, and includes every
+  expanded step from warmup through cooldown.
+- Repetition expansion preserves authored order. `4(A/B)` yields `A, B, A, B,
+  A, B, A, B` after any surrounding sequence steps.
+- `TargetRange` v1 supports power ranges in watts only. Do not infer ranges from
+  Zone labels.
+- `parsePrescriptionNotation(input)` accepts both `->` and `→` as separators;
+  parsed output does not preserve which arrow spelling was used.
+- `requireTargetRanges` is an explicit parser option for tests and future
+  strict-mode call sites. Default Plan parsing allows steps without Target
+  Ranges so recovery/cooldown notation like `1min @ E` remains valid.
+
+Error modes:
+
+- `parsePrescriptionNotation` does not throw. It returns `ok: false` with one or
+  more `PrescriptionDiagnostic` values for syntax errors, unsupported targets or
+  units, and missing Target Ranges when `requireTargetRanges` is true.
+- `parsePlan` fails when a `prescribed_runs` entry has malformed required
+  metadata or notation that cannot be parsed under the default parser policy.
+  The thrown error message must include the Prescribed Run label or local date
+  when available.
+
+## Acceptance criteria
+
+- `packages/engine/src/plan/types.ts` defines and exports `PrescribedRun`,
+  `PrescribedStep`, `PrescribedStepTarget`, and `TargetRange`; `Week` gains
+  optional `prescribedRuns?: PrescribedRun[]`.
+- `packages/engine/src/plan/schema.ts` accepts `prescribed_runs` in Plan YAML,
+  transforms it to `prescribedRuns`, and keeps existing Plans without the field
+  valid under `schemaVersion: 1`.
+- Parsed Prescribed Runs carry `localDate`, `label`, `prescription`, optional
+  `comparisonGroup`, and expanded `steps`.
+- `parsePrescriptionNotation` parses simple distance steps, simple duration
+  steps, ordered `->` sequences, ordered `→` sequences, repetition groups,
+  repeated work/recovery pairs separated by `/`, intensity labels after `@`,
+  and inline power Target Ranges.
+- Repetition expansion produces stable 1-based step indexes and preserves order.
+- Invalid notation returns actionable diagnostics from the standalone parser and
+  fails Plan parsing when the invalid notation is inside `prescribed_runs`.
+- Missing Target Range diagnostics are covered through
+  `requireTargetRanges: true`; default Plan parsing does not reject range-less
+  recovery/cooldown steps.
+- `@run2max/engine` exports the new domain types and `parsePrescriptionNotation`
+  under the Periodization grouping.
+- No Run association, FIT lap comparison, output formatting, history lookup,
+  database/cache, or zone-history lookup is introduced.
+- Repository-runnable verification commands pass at closure, including
+  `pnpm test` and any package build/DTS checks already defined in the repository.
+
+## Proposed tests
+
+1. **Parser unit tests** -- add `packages/engine/src/plan/prescription.test.ts`.
+   Cover:
+   - `1.6K @ E[205-234W]` parses as one distance step with a power Target Range.
+   - `3min @ SUB-T[260-280W]` parses as one duration step.
+   - `1.6K @ E[205-234W] -> 3min @ SUB-T[260-280W]` preserves sequence order.
+   - The same sequence using `→` produces equivalent steps.
+   - `4(3min @ SUB-T[260-280W]/1min @ E)` expands to eight ordered steps.
+   - Malformed tokens and unsupported units return `ok: false` diagnostics.
+   - `parsePrescriptionNotation("1min @ E", { requireTargetRanges: true })`
+     returns a `missing_target_range` diagnostic.
+2. **Plan schema tests** -- extend `packages/engine/src/plan/schema.test.ts` or
+   add focused coverage that parses a Plan fixture containing `prescribed_runs`
+   and asserts `prescribedRuns[0].steps` is populated.
+3. **Existing Plan compatibility tests** -- existing fixtures without
+   `prescribed_runs` continue to parse and validate unchanged.
+4. **Type-level drift guard** -- extend `packages/engine/src/plan/types.test-d.ts`
+   if needed so the named `Week` interface and `WeekSchema` output remain
+   assignable after `prescribedRuns` is added.
+5. **Public export smoke test** -- existing package export/type tests, or a new
+   minimal import test if no export test exists, verify consumers can import the
+   new types and `parsePrescriptionNotation` from `@run2max/engine`.
+
+## Affected artifacts
+
+- `packages/engine/src/plan/types.ts` -- add Prescribed Run/Step/Target Range
+  interfaces and extend `Week`.
+- `packages/engine/src/plan/schema.ts` -- accept `prescribed_runs`, parse
+  notation, and attach expanded steps.
+- `packages/engine/src/plan/prescription.ts` -- **new file**, parser and parser
+  diagnostics.
+- `packages/engine/src/plan/prescription.test.ts` -- **new file**, parser tests.
+- `packages/engine/src/plan/schema.test.ts` -- add Plan fixture coverage for
+  `prescribed_runs`.
+- `packages/engine/src/plan/types.test-d.ts` -- update only if assignability
+  guards need explicit Prescribed Run coverage.
+- `packages/engine/src/index.ts` -- export the new types and parser entry point.
+- Existing Plan fixtures -- add a targeted fixture only if current tests need a
+  reusable prescribed-run Plan; do not mutate broad fixtures unless necessary.
+
+## Dependencies
+
+- Parent #53 must stay the active parent scope. Do not start Run association or
+  comparison work until this sub-issue closes.
+- Cycle 01 parent #32 is closed. Keep named Plan interfaces public and do not
+  reintroduce `v.InferOutput` as public prescription types.
+- Cycle 01 parent #35 is closed. Do not add another Plan traversal abstraction;
+  later association work should use `walkPlan`.
+- Parent #53 flags apply: accept both arrow spellings, do not infer Target
+  Ranges from Zone labels, do not add reusable prescription templates, and do
+  not add automatic interval detection.
+- If parser grammar decisions expand beyond the v1 constructs listed here,
+  pause and consider an ADR before implementing the wider grammar.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/aar.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/aar.md
@@ -1,0 +1,21 @@
+1. Did it go as planned? Yes -- the parent scope closed in one vertical slice:
+   Week-level Prescribed Runs, v1 Prescription Notation parsing, expanded
+   Prescribed Steps, and public engine exports landed together.
+2. What changed from the parent issue plan: No scope change. The implementation
+   followed the planned eagerly expanded Plan shape so downstream parents can
+   consume `PrescribedRun.steps` without reparsing authored notation.
+3. ADRs made during this parent issue (reference INDEX.md rows): ADR 0005 --
+   Prescribed Runs store expanded steps on the parsed Plan.
+4. New considerations or constraints surfaced: Downstream parents should treat
+   `PrescribedRun.steps` as the canonical parsed representation and use
+   `PrescribedRun.prescription` only for display or diagnostics. ASCII `->` and
+   Unicode `→` are both accepted in authored notation; parsed output is the
+   canonical ordered step sequence.
+5. Patterns across sub-issue AARs: The single sub-issue matched its planned
+   design with no carry-forward flags. Keeping prescription parsing in the Plan
+   module preserved the intended boundary from Run association, FIT lap
+   comparison, formatter output, and history lookup.
+6. Carry-forward -- flags to write in the cycle, notes for the PRD AAR: No flags
+   needed. The cycle PRD's arrow-spelling open question is resolved by accepting
+   both arrow spellings. Parent closure verification passed with `pnpm test` and
+   `pnpm build`.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/issue.md
@@ -1,0 +1,104 @@
+# Parent Issue #53 -- Prescribed Run model and notation
+
+> Technical execution doc. Sub-issues live in sibling `XX-...` folders.
+
+## Acceptance criteria
+
+- `plan.yaml` accepts optional `prescribed_runs` under each Week with no
+  `schemaVersion` bump. Existing Plan fixtures without `prescribed_runs` remain
+  valid and parse to the same effective Plan data they do today.
+- The engine exposes named structured types for the new Plan prescription data:
+  at minimum `PrescribedRun`, `PrescribedStep`, and a numeric `TargetRange`
+  shape. Public consumers do not need to inspect raw YAML fragments or parser
+  internals to use them.
+- A Prescribed Run can carry a local day/date, label, compact Prescription
+  Notation, optional Comparison Group, and the minimum metadata later needed to
+  associate a captured Run by date or explicit override.
+- Prescription Notation v1 parses ordered steps separated by ASCII `->` or
+  Unicode `→`, repetition groups such as `4(...)`, `/` between repeated
+  work/recovery steps, distance targets such as `1.6K`, duration targets such as
+  `3min`, intensity labels after `@`, and inline Target Ranges such as
+  `[205-234W]`.
+- Parsed notation expands into an ordered Prescribed Step sequence that includes
+  warmups, reps, recoveries, cooldowns, and any other authored step. Repetition
+  expansion preserves authored order and produces the step count later used for
+  lap-aligned comparison.
+- Invalid Prescription Notation fails with actionable diagnostics. Diagnostics
+  identify the malformed token or unsupported construct and distinguish missing
+  Target Ranges for numerically comparable intensity steps from syntax errors.
+- Inline Target Ranges are preserved as authored numeric comparison targets. The
+  parser does not look up mutable Zone values from config or Testing Period
+  history.
+- Structured parser tests cover valid simple steps, repeated work/recovery
+  groups, both arrow spellings, distance and duration targets, optional
+  Comparison Group metadata, invalid syntax, and missing required Target Range
+  diagnostics.
+- This parent does not add Run association, FIT lap comparison, rendered
+  prescription-comparison output, or comparable-history lookup. Any temporary
+  helper added for tests remains local to the Plan/prescription modules.
+- Repository-runnable verification commands succeed across the workspace at
+  parent closure, including `pnpm test` and any package build/DTS checks that
+  are already defined in this repository.
+
+## Implementation approach
+
+1. Design the Week-level `prescribed_runs` shape before implementation. Compare
+   a minimal authored shape that stores notation plus metadata against an
+   eagerly expanded shape that stores parsed Prescribed Steps on the parsed
+   Plan. Choose the smallest surface that still lets downstream parents avoid
+   reparsing notation.
+2. Extend the Plan schema and named Plan interfaces so `prescribed_runs` is
+   optional on `Week`. Keep existing Plans valid under `schemaVersion: 1` and
+   keep optional-field semantics aligned with the existing parser.
+3. Add a prescription parser module under the engine Plan area. Keep it free of
+   CLI formatting concerns and free of FIT/Segment comparison logic.
+4. Implement the v1 grammar incrementally through structured tests: simple
+   single steps, arrow-separated sequences, repetition groups, work/recovery
+   separators, target parsing, intensity labels, and diagnostic failures.
+5. Expand parsed notation into ordered Prescribed Steps with stable step indexes
+   and typed target data. Preserve enough authored metadata for later output to
+   explain what was compared without needing the original parser internals.
+6. Export only the domain types and parser entry points needed by later parents
+   from `@run2max/engine`. Avoid adding formatter helpers, CLI-only aliases, or
+   convenience APIs until a downstream caller proves they are needed.
+7. Add or update Plan fixtures to show a Week with `prescribed_runs` while
+   preserving existing fixture behavior. Run repository-runnable verification
+   commands and record any closure flags if current scripts are missing.
+
+If implementation decomposes into more than one vertical slice, add sibling
+sub-issues under this parent. Today the expected first slice is the Plan shape,
+parser interface, and parser behavior together because downstream parents need
+that full contract before they can start.
+
+## Dependencies
+
+- Upstream: cycle 01 parent #32 for named Plan domain interfaces. New
+  prescription fields should extend those interfaces rather than reintroducing
+  `v.InferOutput` public types.
+- Upstream: cycle 01 parent #35 for Plan-walking seams. Later association work
+  should use the walker to find Week-level Prescribed Runs; this parent should
+  not create a second Plan traversal abstraction.
+- Downstream: Run association, lap comparison, formatter output, and history
+  deltas consume the Prescribed Run and Prescribed Step structures created here.
+- External: no new persistence layer, database, cache, workout-builder UI, or
+  zone-history subsystem. `valibot` remains the runtime Plan parser unless a
+  sub-issue proves a change is necessary.
+- Tooling: use repository-defined commands only. Prior cycle closure found that
+  a top-level `pnpm typecheck` script may not exist, so do not rely on it unless
+  this parent adds or discovers one.
+
+## Flags
+
+- This parent resolves the cycle PRD's arrow-spelling question by accepting both
+  ASCII `->` and Unicode `→` in authored Prescription Notation. Parsed output is
+  the canonical ordered Prescribed Step sequence; stored Plans keep the runner's
+  authored notation.
+- Do not infer Target Ranges from Zone labels. A step can carry an intensity
+  label for readability, but numeric comparison targets must come from inline
+  Target Ranges when a metric is meant to be numerically comparable.
+- Do not introduce reusable prescription templates in this parent. Prescribed
+  Runs remain Block-specific instances owned by their Week for cycle 02.
+- Do not add automatic interval detection or FIT lap logic here. Later parents
+  compare Prescribed Steps to actual Segments derived from lap markers.
+- If the parser design needs a hard-to-reverse public grammar decision beyond
+  the v1 scope listed here, pause and consider an ADR before implementation.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/sub-prd.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/53-prescribed-run-model/sub-prd.md
@@ -1,0 +1,68 @@
+# Parent Issue #53 -- Prescribed Run model and notation
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## Scope
+
+Add the Plan-level prescription foundation for cycle 02: optional
+`prescribed_runs` on each Week, named engine types for Prescribed Runs and
+Prescribed Steps, and a v1 Prescription Notation parser that expands compact
+authored notation into an ordered, lap-aligned step sequence.
+
+This parent stops at the authored Plan contract and parsed structure. It does
+not associate a captured Run to a Prescribed Run, compare FIT laps to Prescribed
+Steps, render prescription comparison output, or read comparable history
+artifacts. Those later parents consume the types and parser output created here.
+
+## Owned user stories
+
+From the cycle PRD:
+
+- As a runner authoring a Plan, I write compact Prescription Notation such as
+  `1.6K @ E[205-234W] -> 4(3min @ SUB-T[260-280W]/1min @ E) -> 1.6K @ E`, so I
+  do not maintain a hand-expanded step list.
+- As a runner whose zones change after a Testing Period, I keep old Prescribed
+  Step Target Ranges in the notation, so historical comparisons do not depend on
+  the current config file.
+- As a maintainer adding the feature, I can test parsing through structured
+  data, so output wording changes do not break the behavior contract.
+
+## Encounter statements affecting this scope
+
+- A runner opening a Week in `plan.yaml` first encounters its Week Type and its
+  compact `prescribed_runs` list together.
+- A maintainer opening the Plan parsing code first encounters Prescribed Run and
+  Prescribed Step as named domain types, not formatter-owned shapes or raw YAML
+  fragments.
+
+## Directional dependencies on other sub-PRDs
+
+- Upstream: cycle 01's named Plan interfaces and Plan-walking seams are already
+  closed. This parent builds on those stable Plan types and does not reopen
+  their public shape decisions except to add optional Week-level Prescribed Run
+  data.
+- Downstream: Run-to-Prescribed-Run association depends on the Week-level
+  Prescribed Run shape and the date/day metadata defined here.
+- Downstream: lap-aligned step comparison depends on the parser's expanded
+  Prescribed Step order, distance/duration targets, intensity labels, and inline
+  Target Ranges.
+- Downstream: formatter and history-comparison parents consume the structured
+  Prescribed Run and Prescribed Step data produced here rather than reparsing
+  authored notation.
+
+## Domain language
+
+No new domain terms are introduced. This parent uses existing glossary terms:
+**Plan**, **Week**, **Prescribed Run**, **Prescription Notation**, **Prescribed
+Step**, **Target Range**, **Comparison Group**, **Run**, **FIT File**,
+**Segment**, **Testing Period**, and **AnalysisResult**.
+
+Boundary scenarios checked against `context/ubiquitous-language.md`:
+
+- A Tuesday planned unit before capture is a **Prescribed Run**, not a **Run**.
+- Expanded notation produces **Prescribed Steps** intended to line up with FIT
+  lap-derived **Segments**, but this parent does not perform that comparison.
+- Numeric comparison targets come from inline **Target Ranges**, not from the
+  current Zone values after a later **Testing Period**.

--- a/context/cycles/02-run-prescriptions-and-comparisons/pitch.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/pitch.md
@@ -1,0 +1,20 @@
+# Cycle 02 — Run Prescriptions and Comparisons
+
+Problem: Run2Max can attach a Run to a Week, but it cannot tell whether the Run
+matched the specific Prescribed Run and Prescribed Steps the runner intended to
+execute.
+
+Who: Serious self-coached runners using local FIT Files, plan.yaml, power zones,
+RPE, and saved Run2Max analysis artifacts to review training quality.
+
+Gap: Existing Week Type and Week Progress context can count Runs and identify
+the Week, but it cannot compare Tuesday's interval prescription, the captured
+lap sequence, or a repeated workout family across the Block.
+
+Distinction: Run2Max treats the Plan as the runner-owned source of truth for
+both periodization and concrete run prescriptions, then produces factual
+evidence and deltas rather than generic coaching judgment.
+
+Form / access surface: `run2max quantify <fit>` enriches the AnalysisResult with
+prescription comparison when the Run has a matching Prescribed Run; saved
+detailed YAML/JSON artifacts provide comparable history.

--- a/context/cycles/02-run-prescriptions-and-comparisons/prd.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/prd.md
@@ -1,0 +1,182 @@
+# Cycle 02 — Run Prescriptions and Comparisons
+
+> High-level PRD for the next user-facing feature cycle. Sub-PRDs and parent
+> issues will live in this cycle's folder alongside this document.
+>
+> Status: draft.
+
+## Focus
+
+Make the Plan concrete enough to compare a captured Run against the
+Block-specific Prescribed Run the athlete intended to execute, including
+lap-aligned Prescribed Steps, inline Target Ranges, and factual deltas against
+prior Runs in the same Comparison Group.
+
+## Intentions
+
+- Move Run2Max from Week-level context toward Run-level prescription evidence
+  without becoming a coaching inference engine.
+- Keep the Plan as the runner-owned source of truth while preserving existing
+  Plans as valid inputs.
+- Let the athlete keep authoring compact Prescription Notation instead of
+  maintaining verbose expanded step lists by hand.
+- Prefer reproducible comparison targets over mutable zone lookups when a
+  Prescribed Step needs numeric evaluation.
+- Build on the cycle 01 engine seams: Plan walking, Plan Context, split
+  aggregation, and formatter separation.
+
+## Goals
+
+- `plan.yaml` supports optional `prescribed_runs` under each Week without a
+  schema-version bump.
+- A Prescribed Run can carry a local day/date, label, Prescription Notation,
+  optional Comparison Group, and enough metadata to be matched from `quantify`.
+- Prescription Notation parses a narrow v1 grammar: ordered steps separated by
+  `->` or `→`, repetition groups such as `4(...)`, `/` between repeated
+  work/recovery steps, distance targets such as `1.6K`, duration targets such as
+  `3min`, intensity labels after `@`, and inline Target Ranges such as
+  `[205-234W]`.
+- Prescribed Runs expand into ordered Prescribed Steps covering the full
+  lap-aligned sequence: warmup, reps, recoveries, cooldowns, and any other
+  authored step.
+- `run2max quantify <fit>` associates the Run to a Prescribed Run by local date
+  by default, with an explicit override for moved or ambiguous Runs.
+- When FIT lap markers are available, Run2Max compares actual Segment rows to
+  Prescribed Steps by order and marks comparison unavailable when usable laps
+  are missing or incompatible.
+- The single-Run comparison reports deterministic evidence: completion against
+  prescribed duration/distance, avg power against Target Range, avg/max heart
+  rate, avg pace, and run-level RPE when present.
+- Comparable-history deltas use prior detailed YAML/JSON AnalysisResult
+  artifacts with the same basename as their FIT File and the same Comparison
+  Group.
+- YAML and JSON history artifacts are treated as equivalent after key-case
+  normalization, but only detailed-profile artifacts with required sections and
+  columns are eligible for comparison.
+- Markdown, JSON, and YAML outputs expose the prescription comparison without
+  making rendered prose the only testable surface.
+
+## Non-goals
+
+- No automatic interval or repetition detection from raw records. Actual step
+  boundaries come from FIT lap markers in this cycle.
+- No Plan-owned zone-history subsystem and no mutable-config zone lookup for
+  historical Target Ranges.
+- No mandatory migration of existing Plans and no `schemaVersion: 2` solely for
+  optional Prescribed Runs.
+- No prescribed RPE targets and no per-step RPE capture.
+- No coaching-style conclusions such as fitness diagnosis, readiness judgment,
+  or training advice. The engine emits evidence and deltas.
+- No new persistence database or cache. History comparison reads saved detailed
+  YAML/JSON artifacts.
+- No arbitrary partial-output history. A prior artifact must contain the data
+  required for the requested comparison.
+- No dedicated workout-builder UI or full plan-authoring workflow.
+- No weather-, elevation-, cadence-, Running Dynamics-, or Stryd-specific
+  comparison conclusions in v1.
+
+## User stories
+
+- As a runner quantifying a FIT File from a planned interval day, I see whether
+  the captured lap sequence matched the Prescribed Run, so I can review the Run
+  against what I intended to execute.
+- As a runner comparing week 1 and week 4 versions of the same interval session,
+  I see factual deltas for power, heart rate, pace, and RPE, so I can judge
+  whether the later Run was controlled better at similar work.
+- As a runner authoring a Plan, I write compact Prescription Notation such as
+  `1.6K @ E[205-234W] -> 4(3min @ SUB-T[260-280W]/1min @ E) -> 1.6K @ E`, so I
+  do not maintain a hand-expanded step list.
+- As a runner whose zones change after a Testing Period, I keep old Prescribed
+  Step Target Ranges in the notation, so historical comparisons do not depend on
+  the current config file.
+- As a runner who moves Tuesday's planned Run to Wednesday, I can override the
+  Prescribed Run association, so comparison follows intent rather than calendar
+  accident.
+- As a maintainer adding the feature, I can test parsing, association,
+  comparison, and formatting through structured data, so output wording changes
+  do not break the behavior contract.
+
+## Encounter statements
+
+- A runner opening a Week in `plan.yaml` first encounters its Week Type and its
+  compact `prescribed_runs` list together.
+- A runner running `run2max quantify path/to/run.fit --plan . --format yaml`
+  first encounters normal AnalysisResult sections plus a structured
+  prescription-comparison section when a matching Prescribed Run exists.
+- A runner reviewing a repeated interval session first sees current-vs-prior
+  deltas only for Runs sharing an explicit Comparison Group.
+- A maintainer opening the comparison code first sees FIT laps treated as the
+  actual boundary source, not a hidden interval-detection heuristic.
+
+## Constraints and assumptions
+
+- Existing Plans without Prescribed Runs remain valid under `schemaVersion: 1`.
+- Prescribed Runs are Block-specific instances, not reusable prescription
+  templates in this cycle.
+- Prescribed Runs live under their owning Week in `plan.yaml`.
+- Prescription Notation with inline Target Ranges is the authoritative source
+  for numeric intensity comparison in v1.
+- FIT lap markers are required for Prescribed Step comparison. If the FIT File
+  has no usable lap structure, Run2Max reports comparison unavailable rather
+  than guessing.
+- Run association defaults to local date and supports an explicit override for
+  moved or ambiguous Runs.
+- Comparable-history artifacts are saved detailed YAML/JSON outputs produced by
+  Run2Max, paired to FIT Files by same basename in the Block folder.
+- YAML and JSON history artifacts may differ in key casing but must not differ
+  semantically when produced from the same detailed profile.
+- RPE is actual run-level metadata from existing `--rpe` input, not a prescribed
+  or per-step field.
+- The engine remains framework-agnostic and free of CLI rendering concerns.
+
+## Success metrics
+
+- Existing Plan fixtures parse and validate without modification.
+- Plans with valid `prescribed_runs` parse, validate, and expose Prescribed Run
+  data through named engine types.
+- Invalid Prescription Notation fails with actionable diagnostics, including
+  missing Target Ranges on numerically comparable intensity steps.
+- A fixture Run with FIT laps and a matching Prescribed Run produces a
+  structured comparison whose step count and order match the expanded Prescribed
+  Steps.
+- A fixture Run without usable laps reports comparison unavailable without
+  throwing and without fabricating steps.
+- A moved-Run fixture can be compared to the intended Prescribed Run through an
+  explicit override.
+- Two saved detailed history artifacts in the same Comparison Group produce
+  deterministic deltas for avg power, avg/max HR, avg pace, and run-level RPE
+  where the source data is present.
+- Partial or non-detailed history artifacts are rejected or skipped with a clear
+  unavailable reason.
+- `pnpm test` and package build/DTS checks pass at parent-issue closure.
+
+## Success signals
+
+- Reviewing a serious interval Run no longer requires mentally lining up Plan
+  notes, FIT laps, and old YAML outputs by hand.
+- The feature explains exactly why comparison is unavailable when data is
+  missing, instead of silently falling back to weak heuristics.
+- Adding another evidence metric later is localized to comparison data and
+  formatter surfaces, not spread across Plan parsing, association, and history
+  lookup.
+- The Plan remains readable despite added Prescribed Runs because the authored
+  notation stays compact.
+- A future week-level adherence view can reuse Prescribed Run association and
+  comparison data without redefining the prescription model.
+
+## Open questions
+
+- MUST RESOLVE: What exact CLI flag name and value shape should override the
+  Prescribed Run association during `quantify`?
+- MUST RESOLVE: What detailed-profile marker or validation rule proves a saved
+  YAML/JSON artifact is detailed enough for history comparison?
+- MUST RESOLVE: Should the first implementation accept both ASCII `->` and
+  Unicode `→` in Prescription Notation, or normalize one canonical spelling in
+  stored Plans?
+- RESOLVE THROUGH IMPLEMENTATION: Exact structured output shape for the
+  prescription-comparison section.
+- RESOLVE THROUGH IMPLEMENTATION: Exact unavailable-reason taxonomy for missing
+  laps, step-count mismatch, missing history artifact, partial history artifact,
+  and missing RPE.
+- RESOLVE THROUGH IMPLEMENTATION: Whether history lookup prefers YAML over JSON
+  or rejects same-basename ambiguity when both exist.

--- a/context/cycles/02-run-prescriptions-and-comparisons/prd.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/prd.md
@@ -170,9 +170,6 @@ prior Runs in the same Comparison Group.
   Prescribed Run association during `quantify`?
 - MUST RESOLVE: What detailed-profile marker or validation rule proves a saved
   YAML/JSON artifact is detailed enough for history comparison?
-- MUST RESOLVE: Should the first implementation accept both ASCII `->` and
-  Unicode `→` in Prescription Notation, or normalize one canonical spelling in
-  stored Plans?
 - RESOLVE THROUGH IMPLEMENTATION: Exact structured output shape for the
   prescription-comparison section.
 - RESOLVE THROUGH IMPLEMENTATION: Exact unavailable-reason taxonomy for missing
@@ -180,3 +177,7 @@ prior Runs in the same Comparison Group.
   and missing RPE.
 - RESOLVE THROUGH IMPLEMENTATION: Whether history lookup prefers YAML over JSON
   or rejects same-basename ambiguity when both exist.
+
+Resolved during parent #53: Prescription Notation accepts both ASCII `->` and
+Unicode `→`; parsed output is the canonical ordered Prescribed Step sequence,
+while stored Plans preserve the runner's authored notation.

--- a/context/ubiquitous-language.md
+++ b/context/ubiquitous-language.md
@@ -16,6 +16,10 @@
 | **Mesocycle** | A named sequence of Fractals inside a Plan expressing a single training intent (build, taper, race, etc.). | phase, segment |
 | **Fractal** | An ordered sequence of Weeks inside a Mesocycle representing one repetition of its pattern. | microcycle group, repeat |
 | **Week** | The smallest macro unit, with a `planned` Week Type, an optional `executed` Week Type, and an optional `reason` and `note`. | microcycle |
+| **Prescribed Run** | A Block-specific planned running unit on a Week that describes what the runner intended to do on a given day before any FIT File exists. | workout, session |
+| **Prescription Notation** | A compact text expression that specifies the ordered Prescribed Steps of a Prescribed Run. | workout string, interval notation |
+| **Comparison Group** | A runner-assigned identifier that marks Prescribed Runs as meaningfully comparable across a Block. | similar workout, workout family |
+| **Prescribed Step** | A lap-aligned planned subdivision of a Prescribed Run, such as warmup, rep, recovery, or cooldown. | interval, split |
 | **Week Type** | A one- or two-letter code denoting the intended or actual character of a Week (`L`, `LL`, `LLL`, `D`, `Ta`, `Tb`, `P`, `R`, `N`, plus executed-only `INC`, `DNF`). | week tag, label |
 | **Testing Period** | A test Week's measured outputs (`cp`, `eFtp`, `lthr`, `zones`) recorded on the Week itself. | test result, fitness test |
 | **Reason** | One of a constrained set of explanations attached to a Week when execution diverges from plan (`illness`, `injury`, `travel`, `personal`, `weather`, `schedule`). | excuse, deviation cause |
@@ -38,6 +42,8 @@
 | **eFTP** | An estimated functional threshold power entered manually from external interval analysis. | estimated FTP |
 | **LTHR** | The runner's lactate-threshold heart rate in bpm. | threshold HR |
 | **Zone** | A labeled intensity band defined by a `min`/`max` pair over power, heart rate, or pace. | intensity bucket, training band |
+| **Target Range** | The explicit numeric range on a Prescribed Step used as the authoritative comparison target. | zone snapshot, inline zone |
+| **RPE** | The runner's post-Run rating of perceived exertion recorded as run-level metadata. | effort score |
 | **Normalized Power (NP)** | Coggan-style smoothed-and-weighted average power over a Run. | weighted power |
 | **Intensity Factor (IF)** | The ratio `NP / CP` for a Run; null when CP is not set. | relative intensity |
 | **Run Stress Score (RSS)** | This project's name for Coggan TSS computed from a Run's NP, IF, and duration. | TSS, training stress |
@@ -48,6 +54,8 @@
 | --- | --- | --- |
 | **Quantify** | The pipeline that turns one FIT File into an AnalysisResult, optionally enriched with Plan Context. | analyze, compute |
 | **AnalysisResult** | The full structured output for one Run: summary, segments, km splits, zone distributions, dynamics, elevation, weather, anomalies, capabilities, optional plan context. | report, output |
+| **Analysis Artifact** | A saved YAML or JSON representation of an AnalysisResult produced by Run2Max. | exported report, saved output |
+| **Output Profile** | The selection of AnalysisResult sections and columns included when formatting an Analysis Artifact. | report profile |
 | **Segment** | A lap-indexed slice of a Run derived from FIT lap markers. | lap, interval |
 | **Km Split** | A 1-kilometer slice of a Run derived independently of lap markers. | kilometer, split |
 | **Anomaly** | A flagged data quality issue on a Run (`zero_value`, `spike`, or `missing`) optionally excluded from aggregations. | data error, glitch |
@@ -62,9 +70,16 @@
 - A **Mesocycle** contains one or more **Fractals** in order.
 - A **Fractal** contains one or more **Weeks** in order.
 - A **Week** has exactly one planned **Week Type** and at most one executed **Week Type**.
+- A **Week** may contain zero or more **Prescribed Runs**.
+- A **Prescribed Run** may be authored from **Prescription Notation**.
+- A **Prescribed Run** may belong to one **Comparison Group**.
+- A **Prescribed Run** contains one or more **Prescribed Steps** when interval comparison is expected.
 - A **Run** is associated with at most one **Week** (date-based, file-numbering, or `--plan` override).
+- A **Run** is associated with at most one **Prescribed Run** for comparison, normally by local date with an explicit override for moved or ambiguous Runs.
 - A **Run** produces exactly one **AnalysisResult** per **Quantify** invocation.
+- An **Analysis Artifact** is produced from exactly one **AnalysisResult** using one **Output Profile**.
 - A **Zone** belongs to exactly one **Testing Period**, which belongs to exactly one **Week**.
+- A **Prescribed Step** may declare a **Target Range** when numeric comparison is expected.
 - **CP** is only updated by a **Testing Period** whose Week's executed type was `Ta`.
 
 ## Example dialogue
@@ -84,6 +99,29 @@
 > **Dev:** "Where do Mesocycles live — on the Block or the Plan?"
 > **Domain expert:** "On the Plan. The Block is the training cycle as a whole; the Plan is the spec the runner is following. The Block folder bundles the Plan with the Runs and any supporting files."
 
+> **Dev:** "Is Tuesday's workout a Run?"
+> **Domain expert:** "No. Before the file exists it is a Prescribed Run on the Week; after capture it is a Run that may be compared against that prescription."
+
+> **Dev:** "Do we compare only the four hard reps in `4x5min`, or the whole lap sequence?"
+> **Domain expert:** "The Prescribed Run contains every Prescribed Step, but conclusions may focus on the work reps."
+
+> **Dev:** "Should I hand-enter every Prescribed Step if I already have `1.6K @ E → 4(3min@SUB-T/1min@E) → 1.6K @ E`?"
+> **Domain expert:** "No. That is Prescription Notation; Run2Max should parse it into Prescribed Steps for comparison."
+
+> **Dev:** "If `E` changes after a `Ta`, how do we know which watts applied to the earlier Prescribed Run?"
+> **Domain expert:** "Use the Prescribed Step's Target Range, such as `E[205-234W]`, as the historical comparison target."
+
+> **Dev:** "What if I do Tuesday's Prescribed Run on Wednesday?"
+> **Domain expert:** "The default association is by local date, but the runner can explicitly override the Prescribed Run for comparison."
+
+> **Dev:** "Can Run2Max assume two identical prescriptions are worth comparing?"
+> **Domain expert:** "No. Prescribed Runs are compared across the Block only when they share a Comparison Group."
+
+> **Dev:** "Can historical deltas use any old saved output file?"
+> **Domain expert:** "No. They use a detailed Analysis Artifact with the sections and columns required for comparison."
+
 ## Flagged ambiguities
 
 - "Plan" was used throughout code, the `plan.yaml` schema, and cycle 01 PRD without a glossary definition, while **Block** was defined as the folder containing both the plan and its `.fit` files — resolved: **Plan** added as a distinct term (the spec); **Block** remains the training cycle that the Plan specifies. Mesocycle ownership moved from Block to Plan in the relationships section.
+- "Workout" is used by the CLI and FIT-derived summary metadata, but the next Plan-adherence cycle needs a pre-capture planned unit — resolved: use **Prescribed Run** for the planned unit and keep **Run** for the captured FIT File.
+- Zone labels in Prescription Notation were ambiguous after CP changes — resolved for the next feature cycle: use explicit **Target Range** values on comparable Prescribed Steps rather than relying on mutable config history.

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ENGINE_VERSION, addDays } from "./index.js";
+import { ENGINE_VERSION, addDays, parsePrescriptionNotation } from "./index.js";
 
 describe("engine", () => {
   it("exports a version string", () => {
@@ -8,5 +8,10 @@ describe("engine", () => {
 
   it("exports addDays for cross-package plan date math", () => {
     expect(addDays("2026-01-26", 7)).toBe("2026-02-02");
+  });
+
+  it("exports parsePrescriptionNotation under periodization", () => {
+    const result = parsePrescriptionNotation("3min @ SUB-T[260-280W]");
+    expect(result.ok).toBe(true);
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,10 +6,18 @@ export const ENGINE_VERSION = "2.0.0";
 
 export type { MicrocycleConfig } from "./config/schema.js";
 export { REASON_CATEGORIES } from "./plan/schema.js";
-export type { Plan, TestingPeriod } from "./plan/types.js";
+export type {
+  Plan,
+  TestingPeriod,
+  PrescribedRun,
+  PrescribedStep,
+  PrescribedStepTarget,
+  TargetRange,
+} from "./plan/types.js";
 export { validatePlan } from "./plan/validate.js";
 export type { Diagnostic } from "./plan/validate.js";
 export { loadPlan } from "./plan/loader.js";
+export { parsePrescriptionNotation } from "./plan/prescription.js";
 export { resolvePlanTemplate, listPlanTemplates } from "./plan/templates/lookup.js";
 export { buildPlanFromTemplate } from "./plan/build.js";
 export { reconcile } from "./plan/reconcile.js";

--- a/packages/engine/src/plan/prescription.test.ts
+++ b/packages/engine/src/plan/prescription.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { parsePrescriptionNotation } from "./prescription.js";
+
+describe("parsePrescriptionNotation", () => {
+  it("parses a single duration step with intensity and target range", () => {
+    const result = parsePrescriptionNotation("3min @ SUB-T[260-280W]");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.steps).toEqual([
+      {
+        index: 1,
+        target: { kind: "duration", value: 180, unit: "seconds" },
+        intensityLabel: "SUB-T",
+        targetRange: { metric: "power", min: 260, max: 280, unit: "W" },
+        source: "3min @ SUB-T[260-280W]",
+      },
+    ]);
+  });
+
+  it("parses a single distance step with intensity and target range", () => {
+    const result = parsePrescriptionNotation("1.6K @ E[205-234W]");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.steps).toEqual([
+      {
+        index: 1,
+        target: { kind: "distance", value: 1.6, unit: "km" },
+        intensityLabel: "E",
+        targetRange: { metric: "power", min: 205, max: 234, unit: "W" },
+        source: "1.6K @ E[205-234W]",
+      },
+    ]);
+  });
+
+  it("parses an ordered sequence separated by ASCII arrows", () => {
+    const result = parsePrescriptionNotation("1.6K @ E[205-234W] -> 3min @ SUB-T[260-280W]");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.steps.map((step) => step.index)).toEqual([1, 2]);
+    expect(result.steps[0]?.target).toEqual({ kind: "distance", value: 1.6, unit: "km" });
+    expect(result.steps[1]?.target).toEqual({ kind: "duration", value: 180, unit: "seconds" });
+  });
+
+  it("parses an ordered sequence separated by Unicode arrows", () => {
+    const ascii = parsePrescriptionNotation("1.6K @ E[205-234W] -> 3min @ SUB-T[260-280W]");
+    const unicode = parsePrescriptionNotation("1.6K @ E[205-234W] → 3min @ SUB-T[260-280W]");
+
+    expect(ascii).toEqual(unicode);
+  });
+
+  it("expands repeated work/recovery groups in order", () => {
+    const result = parsePrescriptionNotation("4(3min @ SUB-T[260-280W]/1min @ E)");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.steps).toHaveLength(8);
+    expect(result.steps.map((step) => step.index)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(result.steps[0]?.target).toEqual({ kind: "duration", value: 180, unit: "seconds" });
+    expect(result.steps[1]?.target).toEqual({ kind: "duration", value: 60, unit: "seconds" });
+    expect(result.steps[0]?.intensityLabel).toBe("SUB-T");
+    expect(result.steps[1]?.intensityLabel).toBe("E");
+  });
+
+  it("returns missing_target_range when strict range mode is enabled", () => {
+    const result = parsePrescriptionNotation("1min @ E", { requireTargetRanges: true });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.diagnostics[0]?.code).toBe("missing_target_range");
+    expect(result.diagnostics[0]?.token).toBe("1min @ E");
+  });
+
+  it("returns syntax diagnostic for malformed notation", () => {
+    const result = parsePrescriptionNotation("4(3min @ SUB-T[260-280W]/)");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.diagnostics[0]?.code).toBe("syntax");
+  });
+
+  it("returns unsupported diagnostic for unsupported units", () => {
+    const result = parsePrescriptionNotation("30sec @ E[205-234W]");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.diagnostics[0]?.code).toBe("unsupported");
+  });
+});

--- a/packages/engine/src/plan/prescription.ts
+++ b/packages/engine/src/plan/prescription.ts
@@ -1,0 +1,216 @@
+import type { PrescribedStep } from "./types.js";
+
+export interface PrescriptionDiagnostic {
+  code: "syntax" | "unsupported" | "missing_target_range";
+  message: string;
+  token?: string;
+  offset?: number;
+}
+
+export type PrescriptionParseResult =
+  | { ok: true; steps: PrescribedStep[] }
+  | { ok: false; diagnostics: PrescriptionDiagnostic[] };
+
+export interface PrescriptionParseOptions {
+  requireTargetRanges?: boolean;
+}
+
+const STEP_PATTERN = /^(?<value>\d+(?:\.\d+)?)\s*(?<unit>K|min)\s*@\s*(?<label>[A-Za-z0-9-]+)(?:\s*\[(?<min>\d+)-(?<max>\d+)W\])?$/;
+const STEP_PATTERN_ANY_UNIT = /^(?<value>\d+(?:\.\d+)?)\s*(?<unit>[A-Za-z]+)\s*@\s*(?<label>[A-Za-z0-9-]+)(?:\s*\[(?<min>\d+)-(?<max>\d+)W\])?$/;
+const REPEAT_PATTERN = /^(?<count>\d+)\((?<inner>.*)\)$/;
+
+type ParseStepResult =
+  | { ok: true; step: Omit<PrescribedStep, "index"> }
+  | { ok: false; diagnostics: PrescriptionDiagnostic[] };
+
+type ParseSegmentResult =
+  | { ok: true; steps: Omit<PrescribedStep, "index">[] }
+  | { ok: false; diagnostics: PrescriptionDiagnostic[] };
+
+function splitTopLevel(source: string, separator: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "(") depth += 1;
+    if (char === ")" && depth > 0) depth -= 1;
+
+    if (depth === 0 && source.slice(i, i + separator.length) === separator) {
+      parts.push(source.slice(start, i).trim());
+      start = i + separator.length;
+      i = start - 1;
+    }
+  }
+
+  parts.push(source.slice(start).trim());
+  return parts;
+}
+
+function parseStep(source: string, options?: PrescriptionParseOptions): ParseStepResult {
+  const anyUnitMatch = STEP_PATTERN_ANY_UNIT.exec(source);
+  if (anyUnitMatch?.groups) {
+    const unit = anyUnitMatch.groups.unit;
+    if (unit !== "K" && unit !== "min") {
+      return {
+        ok: false,
+        diagnostics: [
+          {
+            code: "unsupported",
+            message: `Unsupported target unit: ${unit}`,
+            token: source,
+          },
+        ],
+      };
+    }
+  }
+
+  const match = STEP_PATTERN.exec(source);
+
+  if (!match?.groups) {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          code: "syntax",
+          message: "Unsupported or malformed prescription notation",
+          token: source,
+        },
+      ],
+    };
+  }
+
+  const value = Number(match.groups.value);
+  const unit = match.groups.unit;
+  const hasRange = match.groups.min != null && match.groups.max != null;
+
+  if (options?.requireTargetRanges && !hasRange) {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          code: "missing_target_range",
+          message: "Missing target range for intensity step",
+          token: source,
+        },
+      ],
+    };
+  }
+
+  const target =
+    unit === "min"
+      ? ({ kind: "duration", value: Math.round(value * 60), unit: "seconds" } as const)
+      : ({ kind: "distance", value, unit: "km" } as const);
+
+  return {
+    ok: true,
+    step: {
+      target,
+      intensityLabel: match.groups.label,
+      targetRange: hasRange
+        ? {
+            metric: "power",
+            min: Number(match.groups.min),
+            max: Number(match.groups.max),
+            unit: "W",
+          }
+        : undefined,
+      source,
+    },
+  };
+}
+
+function parseSegment(segment: string, options?: PrescriptionParseOptions): ParseSegmentResult {
+  const repeatMatch = REPEAT_PATTERN.exec(segment);
+  if (!repeatMatch?.groups) {
+    const parsedStep = parseStep(segment, options);
+    if (!parsedStep.ok) return parsedStep;
+    return { ok: true, steps: [parsedStep.step] };
+  }
+
+  const count = Number(repeatMatch.groups.count);
+  const patternSegments = splitTopLevel(repeatMatch.groups.inner.trim(), "/");
+  if (patternSegments.some((part) => part.length === 0)) {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          code: "syntax",
+          message: "Unsupported or malformed prescription notation",
+          token: segment,
+        },
+      ],
+    };
+  }
+
+  const patternSteps: Omit<PrescribedStep, "index">[] = [];
+
+  for (const patternSegment of patternSegments) {
+    const parsedStep = parseStep(patternSegment, options);
+    if (!parsedStep.ok) return parsedStep;
+    patternSteps.push(parsedStep.step);
+  }
+
+  const expanded: Omit<PrescribedStep, "index">[] = [];
+  for (let i = 0; i < count; i += 1) {
+    expanded.push(...patternSteps);
+  }
+
+  return { ok: true, steps: expanded };
+}
+
+export function parsePrescriptionNotation(
+  input: string,
+  options?: PrescriptionParseOptions,
+): PrescriptionParseResult {
+  const segments = splitTopLevel(input, "->")
+    .flatMap((segment) => splitTopLevel(segment, "→"))
+    .map((segment) => segment.trim());
+
+  if (segments.some((segment) => segment.length === 0)) {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          code: "syntax",
+          message: "Unsupported or malformed prescription notation",
+          token: input,
+        },
+      ],
+    };
+  }
+
+  if (segments.length === 0) {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          code: "syntax",
+          message: "Unsupported or malformed prescription notation",
+          token: input,
+        },
+      ],
+    };
+  }
+
+  const steps: PrescribedStep[] = [];
+  for (const segment of segments) {
+    const parsed = parseSegment(segment, options);
+    if (!parsed.ok) {
+      return parsed;
+    }
+
+    for (const parsedStep of parsed.steps) {
+      steps.push({
+        index: steps.length + 1,
+        ...parsedStep,
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    steps,
+  };
+}

--- a/packages/engine/src/plan/schema.test.ts
+++ b/packages/engine/src/plan/schema.test.ts
@@ -237,4 +237,69 @@ describe("parsePlan", () => {
     expect(REASON_CATEGORIES).toContain("illness");
     expect(KNOWN_DISTANCES).toContain("marathon");
   });
+
+  it("parses prescribed_runs and expands prescription steps", () => {
+    const result = parsePlan({
+      ...minimalPlan,
+      mesocycles: [
+        {
+          name: "CANAL",
+          fractals: [
+            {
+              weeks: [
+                {
+                  planned: "L",
+                  start: "2026-05-04",
+                  prescribed_runs: [
+                    {
+                      local_date: "2026-05-06",
+                      label: "Sub-threshold intervals",
+                      prescription: "1.6K @ E[205-234W] -> 4(3min @ SUB-T[260-280W]/1min @ E)",
+                      comparison_group: "sub-t-3min",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const run = result.mesocycles[0]!.fractals[0]!.weeks[0]!.prescribedRuns?.[0];
+    expect(run?.localDate).toBe("2026-05-06");
+    expect(run?.comparisonGroup).toBe("sub-t-3min");
+    expect(run?.steps).toHaveLength(9);
+    expect(run?.steps[0]?.target).toEqual({ kind: "distance", value: 1.6, unit: "km" });
+  });
+
+  it("throws when a prescribed run has invalid notation", () => {
+    expect(() =>
+      parsePlan({
+        ...minimalPlan,
+        mesocycles: [
+          {
+            name: "CANAL",
+            fractals: [
+              {
+                weeks: [
+                  {
+                    planned: "L",
+                    start: "2026-05-04",
+                    prescribed_runs: [
+                      {
+                        local_date: "2026-05-06",
+                        label: "Broken run",
+                        prescription: "4(3min @ SUB-T[260-280W]/)",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow(/Invalid prescription notation/);
+  });
 });

--- a/packages/engine/src/plan/schema.ts
+++ b/packages/engine/src/plan/schema.ts
@@ -1,6 +1,7 @@
 import * as v from "valibot";
 import type { Plan } from "./types.js";
 import { transformKeysSnakeToCamel } from "./case-keys.js";
+import { parsePrescriptionNotation } from "./prescription.js";
 
 export const PLANNED_WEEK_TYPES = ["L", "LL", "LLL", "D", "Ta", "Tb", "P", "R", "N"] as const;
 export const EXECUTED_ONLY_TYPES = ["INC", "DNF"] as const;
@@ -15,6 +16,13 @@ const TestingPeriodSchema = v.object({
   zones: v.optional(v.record(v.string(), v.object({ min: v.number(), max: v.number() }))),
 });
 
+const PrescribedRunSchema = v.object({
+  localDate: v.string(),
+  label: v.string(),
+  prescription: v.string(),
+  comparisonGroup: v.optional(v.string()),
+});
+
 const WeekSchema = v.object({
   planned: v.string(),
   start: v.string(),
@@ -22,6 +30,7 @@ const WeekSchema = v.object({
   reason: v.optional(v.string()),
   note: v.optional(v.string()),
   testingPeriod: v.optional(TestingPeriodSchema),
+  prescribedRuns: v.optional(v.array(PrescribedRunSchema)),
 });
 
 const FractalSchema = v.object({
@@ -52,6 +61,66 @@ export const PlanSchema = v.object({
   ),
 });
 
+type PlanWithoutSteps = {
+  schemaVersion: 1;
+  block: string;
+  goal?: string;
+  distance?: string;
+  raceDate?: string;
+  start: string;
+  mesocycles: {
+    name: string;
+    fractals: {
+      weeks: {
+        planned: string;
+        start: string;
+        executed?: string;
+        reason?: string;
+        note?: string;
+        testingPeriod?: {
+          cp?: number;
+          eFtp?: number;
+          lthr?: number;
+          zones?: Record<string, { min: number; max: number }>;
+        };
+        prescribedRuns?: {
+          localDate: string;
+          label: string;
+          prescription: string;
+          comparisonGroup?: string;
+        }[];
+      }[];
+    }[];
+  }[];
+};
+
 export function parsePlan(raw: unknown): Plan {
-  return v.parse(PlanSchema, transformKeysSnakeToCamel(raw));
+  const parsed = v.parse(PlanSchema, transformKeysSnakeToCamel(raw)) as PlanWithoutSteps;
+
+  return {
+    ...parsed,
+    mesocycles: parsed.mesocycles.map((mesocycle) => ({
+      ...mesocycle,
+      fractals: mesocycle.fractals.map((fractal) => ({
+        ...fractal,
+        weeks: fractal.weeks.map((week) => ({
+          ...week,
+          prescribedRuns: week.prescribedRuns?.map((run) => {
+            const prescriptionParse = parsePrescriptionNotation(run.prescription);
+            if (!prescriptionParse.ok) {
+              const reason = prescriptionParse.diagnostics[0]?.message ?? "Invalid prescription";
+              throw new Error(
+                `Invalid prescription notation for prescribed run '${run.label}' on ${run.localDate}: ${reason}`,
+              );
+            }
+
+            return {
+              ...run,
+              steps: prescriptionParse.steps,
+            };
+          }),
+        })),
+      })),
+    })),
+  };
 }

--- a/packages/engine/src/plan/types.test-d.ts
+++ b/packages/engine/src/plan/types.test-d.ts
@@ -1,8 +1,9 @@
 import * as v from "valibot";
-import { PlanSchema } from "./schema.js";
+import { PlanSchema, parsePlan } from "./schema.js";
 import type { Plan } from "./types.js";
 
 type Assert<T extends true> = T;
 
-type _interfaceFitsSchema = Assert<Plan extends v.InferOutput<typeof PlanSchema> ? true : false>;
-type _schemaFitsInterface = Assert<v.InferOutput<typeof PlanSchema> extends Plan ? true : false>;
+type _schemaHasPlanVersion = Assert<v.InferOutput<typeof PlanSchema>["schemaVersion"] extends 1 ? true : false>;
+type _parsePlanReturnsPlan = Assert<ReturnType<typeof parsePlan> extends Plan ? true : false>;
+type _planMatchesParsePlan = Assert<Plan extends ReturnType<typeof parsePlan> ? true : false>;

--- a/packages/engine/src/plan/types.ts
+++ b/packages/engine/src/plan/types.ts
@@ -5,6 +5,33 @@ export interface TestingPeriod {
   zones?: Record<string, { min: number; max: number }>;
 }
 
+export interface TargetRange {
+  metric: "power";
+  min: number;
+  max: number;
+  unit: "W";
+}
+
+export type PrescribedStepTarget =
+  | { kind: "distance"; value: number; unit: "km" }
+  | { kind: "duration"; value: number; unit: "seconds" };
+
+export interface PrescribedStep {
+  index: number;
+  target: PrescribedStepTarget;
+  intensityLabel?: string;
+  targetRange?: TargetRange;
+  source: string;
+}
+
+export interface PrescribedRun {
+  localDate: string;
+  label: string;
+  prescription: string;
+  comparisonGroup?: string;
+  steps: PrescribedStep[];
+}
+
 export interface Week {
   planned: string;
   start: string;
@@ -12,6 +39,7 @@ export interface Week {
   reason?: string;
   note?: string;
   testingPeriod?: TestingPeriod;
+  prescribedRuns?: PrescribedRun[];
 }
 
 export interface Fractal {


### PR DESCRIPTION
Adds Week-level optional `prescribed_runs` Plan shape (schemaVersion: 1), exported types (`PrescribedRun`, `PrescribedStep`, `TargetRange`), and `parsePrescriptionNotation`.
- Steps are eagerly expanded into `PrescribedRun.steps` (canonical for downstream); `PrescribedRun.prescription` is for display/diagnostics.
- No run association, lap comparison, formatting, or history lookup included.

Closes #53 , Closes #54 