### PR TITLE
Adds prescribed-run association and CLI `--prescribed-run` override

### DIFF
--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/aar.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/aar.md
@@ -1,0 +1,11 @@
+1. Did it go as planned? Yes -- the pure engine association contract landed with
+   structured overrides, quantify integration, and passing tests/build checks.
+2. What changed from the sub-issue plan: The slice intentionally stayed
+   engine-only. CLI override flag parsing and formatter-facing unavailable output
+   were not implemented because the parent access-surface decision is still open.
+3. Carry-forward -- flags to write in the parent, divergence to note for future
+   siblings, notes for the parent issue's AAR: Add a sibling sub-issue to resolve
+   and implement the quantify override access surface (CLI flag name/value shape)
+   and map that input to `QuantifyOptions.prescribedRunOverride`. Keep
+   `planContext` date-based even when override selects a Prescribed Run in a
+   different Week.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/sub-issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/sub-issue.md
@@ -1,0 +1,351 @@
+# Sub-Issue #57 -- Implement engine Prescribed Run association
+
+Vertical slice for parent #56. Delivers the pure engine association contract,
+structured override options, and minimal `quantify` integration needed for
+downstream lap comparison. This sub-issue intentionally does not add the CLI
+override flag because the cycle PRD's access-surface question is still awaiting
+explicit approval.
+
+## Description
+
+Add an engine function that associates a captured Run with at most one
+Prescribed Run from a parsed Plan. Default association uses the Run's local date
+to find the containing Week, then matches a Prescribed Run on that same
+`localDate`. Structured override options can point at a Prescribed Run by local
+date, label, or both across the entire Plan so moved Runs can follow intent even
+when they cross Week boundaries.
+
+Integrate the association into `quantify` only through structured engine
+options. When a match exists, `AnalysisResult` carries a minimal
+`prescribedRunContext` for downstream comparison. When no match exists, the pure
+association function returns a labeled reason; this sub-issue does not define a
+rendered unavailable message or final prescription-comparison output shape.
+
+Out of scope: CLI flag parsing, rendered formatter output, FIT lap comparison,
+history artifact lookup, prescription reparsing, Plan schema changes, and any
+database/cache/config changes.
+
+## Dependency classification
+
+| Dependency                                                  | Category   | Testing strategy                                                                                           |
+| ----------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
+| `Plan`, `Week`, `PrescribedRun`, and `PrescribedStep` types | In-process | Construct parsed Plan fixtures directly and assert returned matches.                                       |
+| `walkPlan` and `WeekContext`                                | In-process | Exercise through `findPrescribedRun`; assert returned Week metadata comes from the walked Week.            |
+| Existing `associateRun` local-date Week matching behavior   | In-process | Reuse or extract the same date conversion and Week range rules; characterize with timezone boundary tests. |
+| `Intl.DateTimeFormat` timezone conversion                   | In-process | Test with stable UTC and non-UTC cases already used by `associateRun` tests.                               |
+| `QuantifyOptions` and `AnalysisResult` types                | In-process | Test through `quantify` integration and build/DTS output.                                                  |
+| `quantify` pipeline                                         | In-process | Call `quantify` with parsed Plan data and structured override options.                                     |
+| `valibot` Plan parser                                       | In-process | No schema change; use existing parser coverage plus targeted fixtures with `prescribedRuns`.               |
+
+No local-substitutable, remote-owned, collaborator-owned, true external, or
+irreplaceable dependency is introduced. No port is needed because association is
+a pure in-process Plan lookup with no second adapter.
+
+## Interface design
+
+The interface this sub-issue commits to is the public engine association entry
+point and the minimal structured context exposed on `AnalysisResult` when
+`quantify` has both Plan data and a matched Prescribed Run.
+
+### Design-it-twice
+
+**Alternative A -- Quantify-only hidden association**
+
+`quantify` internally finds a Prescribed Run and attaches a context field, but
+no standalone function is exported.
+
+```ts
+export interface QuantifyOptions {
+  plan?: Plan;
+  prescribedRunOverride?: {
+    localDate?: string;
+    label?: string;
+  };
+}
+
+export interface AnalysisResult {
+  prescribedRunContext?: PrescribedRunContext;
+}
+```
+
+- Leverage: low -- downstream tests and future comparison code cannot exercise
+  association without constructing FIT input for `quantify`.
+- Locality: medium -- code stays near `quantify`, but Plan lookup rules become
+  hidden inside the analysis pipeline.
+- Testability: low -- failure reasons are hard to verify without reaching into
+  pipeline internals or asserting absence of output.
+
+**Alternative B -- Pure association function plus structured quantify option**
+
+`findPrescribedRun` is exported from the Plan area. `quantify` calls it when a
+Plan is present and maps a successful match to a minimal context field.
+
+```ts
+// packages/engine/src/plan/associate.ts
+export interface FindPrescribedRunOptions {
+  overrideDate?: string;
+  overrideLabel?: string;
+}
+
+export type FindPrescribedRunReason =
+  | "no_week"
+  | "no_prescribed_run"
+  | "ambiguous";
+
+export interface PrescribedRunMatch {
+  prescribedRun: PrescribedRun;
+  weekContext: WeekContext;
+  matchKind: "date" | "override";
+}
+
+export type FindPrescribedRunResult =
+  | { ok: true; match: PrescribedRunMatch }
+  | { ok: false; reason: FindPrescribedRunReason };
+
+export function findPrescribedRun(
+  plan: Plan,
+  runDate: Date,
+  timezone: string,
+  options?: FindPrescribedRunOptions,
+): FindPrescribedRunResult;
+
+// packages/engine/src/types.ts
+export interface QuantifyOptions {
+  plan?: Plan;
+  prescribedRunOverride?: FindPrescribedRunOptions;
+}
+
+export interface PrescribedRunContext {
+  label: string;
+  localDate: string;
+  comparisonGroup?: string;
+  steps: PrescribedStep[];
+  matchKind: "date" | "override";
+  weekNumber: number;
+  totalWeeks: number;
+  weekType: string;
+  mesocycle: string;
+  fractalIndex: number;
+  totalFractals: number;
+  weekStart: string;
+}
+
+export interface AnalysisResult {
+  prescribedRunContext?: PrescribedRunContext;
+}
+```
+
+Example caller shape:
+
+```ts
+const result = findPrescribedRun(plan, summary.date, timezone, {
+  overrideLabel: "Tuesday Intervals",
+});
+
+if (result.ok) {
+  compareLater(result.match.prescribedRun.steps);
+}
+```
+
+- Leverage: high -- comparison, tests, and later CLI wiring can reuse one
+  association contract.
+- Locality: high -- Plan lookup rules stay in the Plan module, while `quantify`
+  performs only pipeline mapping.
+- Testability: high -- every match and unavailable outcome is asserted without
+  FIT parsing; `quantify` integration needs only smoke coverage.
+
+**Alternative C -- Association plus CLI parsing and unavailable output**
+
+This slice adds `findPrescribedRun`, `quantify` integration, a concrete
+`--prescribed-run <value>` CLI flag, formatter output for unavailable reasons,
+and the final prescription-comparison placeholder.
+
+```ts
+// packages/cli/src/commands/quantify.ts
+// --prescribed-run <value> where YYYY-MM-DD is a date and other values are labels
+
+export interface PrescriptionComparisonUnavailable {
+  reason: "no_prescribed_run" | "ambiguous" | "no_laps";
+  message: string;
+}
+```
+
+- Leverage: medium -- users get an end-to-end access surface immediately, but
+  the slice mixes association with downstream output decisions.
+- Locality: low -- Plan lookup, CLI parsing, formatter prose, and future
+  comparison taxonomy change together.
+- Testability: medium -- more can be smoke-tested, but failures cross too many
+  seams.
+
+### Choice
+
+**B (pure association function plus structured quantify option).** It is the
+smallest public surface that gives downstream comparison a stable association
+contract without prematurely resolving CLI flag syntax or final output shape.
+
+A is rejected in one sentence: hiding association inside `quantify` makes the
+core lookup hard to test and reuse. C is rejected in one sentence: it resolves
+unapproved access-surface and formatter decisions in a slice whose purpose is
+only association.
+
+### Public interface
+
+Entry point:
+
+```ts
+export function findPrescribedRun(
+  plan: Plan,
+  runDate: Date,
+  timezone: string,
+  options?: FindPrescribedRunOptions,
+): FindPrescribedRunResult;
+```
+
+Inputs:
+
+- `plan`: parsed Plan with optional Week-level `prescribedRuns`.
+- `runDate`: captured Run date from `summary.date`.
+- `timezone`: IANA timezone used to convert `runDate` to a local date for
+  default matching.
+- `overrideDate`: optional authored Prescribed Run `localDate` to search for
+  across the Plan.
+- `overrideLabel`: optional authored Prescribed Run `label` to search for across
+  the Plan.
+
+Outputs:
+
+- `ok: true` with `PrescribedRunMatch` when exactly one Prescribed Run matches.
+- `ok: false` with `no_week`, `no_prescribed_run`, or `ambiguous` when no single
+  match can be selected.
+
+Invariants:
+
+- Default matching uses the Run's local date to find the containing Week, then
+  searches only that Week for a Prescribed Run with the same `localDate`.
+- Override matching searches all Weeks in Plan order and is not constrained to
+  the Run date's Week.
+- Supplying both override fields requires both fields to match the same
+  Prescribed Run.
+- A successful override has `matchKind: "override"` even if it points to the
+  same Prescribed Run that default matching would have found.
+- Label matching is exact and case-sensitive; this sub-issue does not introduce
+  fuzzy label matching or label normalization.
+- Multiple matching candidates return `ambiguous` rather than picking the first.
+- When no override is supplied and the Run date falls outside every Week, return
+  `no_week`.
+- When override is supplied, a Run date outside every Week does not block
+  matching; the override still searches the Plan.
+- The function does not mutate Plan data and does not reparse
+  `PrescribedRun.prescription`.
+
+Error modes:
+
+- The function does not throw for normal no-match cases.
+- Invalid timezone behavior remains aligned with existing `associateRun` usage;
+  CLI validation remains outside this sub-issue.
+- Malformed override dates are treated as strings that do not match authored
+  `localDate` values; no date parsing is performed in the association function.
+
+## Acceptance criteria
+
+- `findPrescribedRun` is implemented under `packages/engine/src/plan/` and
+  exported from `@run2max/engine` with its result and option types.
+- Default date matching returns a match only when exactly one Prescribed Run in
+  the date-matched Week has `localDate` equal to the Run's local date.
+- Default matching returns `no_week` when the Run date falls outside every Week.
+- Default matching returns `no_prescribed_run` when the Run date maps to a Week
+  that has no matching Prescribed Run.
+- Default matching returns `ambiguous` when the date-matched Week has multiple
+  matching Prescribed Runs.
+- Override by date searches across the Plan and returns the uniquely matching
+  Prescribed Run, including when that Prescribed Run belongs to a different Week
+  from the captured Run's date.
+- Override by label searches across the Plan and returns the uniquely matching
+  Prescribed Run.
+- Override with both date and label returns a match only when one Prescribed Run
+  satisfies both fields.
+- Override matching returns `no_prescribed_run` for zero matches and `ambiguous`
+  for multiple matches.
+- `quantify` accepts a structured `prescribedRunOverride` option and calls
+  `findPrescribedRun` when parsed Plan data is present.
+- `AnalysisResult.prescribedRunContext` is present only when association matches
+  and includes label, localDate, optional comparisonGroup, steps, matchKind, and
+  owning Week context.
+- Existing `AnalysisResult.planContext` remains date-based and unchanged by a
+  cross-Week Prescribed Run override.
+- No CLI flag, rendered formatter section, lap comparison, or history lookup is
+  introduced in this sub-issue.
+- Repository-runnable verification commands pass at closure, including
+  `pnpm test` and `pnpm build`.
+
+## Proposed tests
+
+1. **Default date match** -- a Run date inside a Week with exactly one
+   Prescribed Run on that local date returns `ok: true` and `matchKind: "date"`.
+2. **Default no Prescribed Run** -- a Run date inside a Week with no matching
+   `prescribedRuns` returns `no_prescribed_run`.
+3. **Default no Week** -- a Run date outside the Plan returns `no_week`.
+4. **Default ambiguous** -- two Prescribed Runs on the same local date in the
+   date-matched Week return `ambiguous`.
+5. **Timezone boundary** -- the same UTC timestamp can match different local
+   dates under different timezones, mirroring existing `associateRun` behavior.
+6. **Override by date across Week boundary** -- a Wednesday captured Run can
+   select a Tuesday Prescribed Run from the previous Week by `overrideDate`.
+7. **Override by label across Week boundary** -- a moved Run can select a
+   Prescribed Run from another Week by exact label.
+8. **Override with both fields** -- date and label must identify the same
+   Prescribed Run.
+9. **Override no match** -- no candidate satisfying the override returns
+   `no_prescribed_run`.
+10. **Override ambiguous** -- duplicate labels or duplicate override dates
+    across the Plan return `ambiguous`.
+11. **Override with Run date outside Plan** -- override can still match a
+    Prescribed Run when the captured Run's date is outside all Weeks.
+12. **No lazy reparse** -- association uses existing `PrescribedRun.steps` and
+    does not call `parsePrescriptionNotation`.
+13. **Quantify default integration** -- `quantify` with a Plan and matching
+    Prescribed Run includes `prescribedRunContext`.
+14. **Quantify no match integration** -- `quantify` with a Plan but no matched
+    Prescribed Run leaves `prescribedRunContext` undefined.
+15. **Quantify override integration** -- `quantify` with `prescribedRunOverride`
+    selects a cross-Week Prescribed Run while preserving date-based
+    `planContext`.
+16. **Public export smoke test** -- consumers can import `findPrescribedRun` and
+    related types from `@run2max/engine`.
+
+## Affected artifacts
+
+- `packages/engine/src/plan/associate.ts` -- add `findPrescribedRun`, result
+  types, structured override options, and any shared local-date helper extracted
+  from existing Week association logic.
+- `packages/engine/src/plan/associate.test.ts` -- add association unit tests for
+  default matching, override matching, ambiguity, no-match reasons, and timezone
+  behavior.
+- `packages/engine/src/types.ts` -- add structured `prescribedRunOverride` to
+  `QuantifyOptions`, add `PrescribedRunContext`, and add optional
+  `prescribedRunContext` to `AnalysisResult`.
+- `packages/engine/src/computations/quantify.ts` -- call `findPrescribedRun`
+  when Plan data is present and map successful matches to
+  `prescribedRunContext`.
+- `packages/engine/src/computations/quantify.test.ts` -- add integration tests
+  for matched, unmatched, and override association behavior.
+- `packages/engine/src/index.ts` -- export the association function and public
+  result/option/context types.
+- `context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md`
+  -- update only if implementation reveals a parent-level flag or scope change.
+
+## Dependencies
+
+- Parent #56 must stay the active parent scope.
+- Closed parent #53 provides parsed Prescribed Run data and expanded
+  `PrescribedRun.steps`; do not reparse Prescription Notation here.
+- Cycle 01 parent #35 provides `walkPlan`; do not add another Plan traversal
+  abstraction.
+- Existing `associateRun` behavior remains the source of truth for date-based
+  Run-to-Week Plan Context. This sub-issue may extract shared local-date helpers
+  only if it reduces duplication without changing behavior.
+- The CLI override flag remains unresolved. Do not add or document a concrete
+  CLI flag in code until the parent issue's access-surface flag is explicitly
+  approved and the cycle PRD is updated.
+- Do not add FIT lap comparison, formatter output, unavailable prose, history
+  artifact lookup, database/cache behavior, or config schema changes.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/58-cli-prescribed-run-override/aar.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/58-cli-prescribed-run-override/aar.md
@@ -1,0 +1,12 @@
+1. Did it go as planned? Yes -- the CLI override access surface landed as a
+   single `--prescribed-run <selector>` flag with parsing, validation, cwd Plan
+   fallback for override mode, and structured pass-through to
+   `QuantifyOptions.prescribedRunOverride`.
+2. What changed from the sub-issue plan: The implementation kept normal
+   no-override auto-discovery unchanged (fit-file directory), while override mode
+   without `--plan` now explicitly tries cwd `plan.yaml` first and fails clearly
+   if missing.
+3. Carry-forward -- flags to write in the parent, divergence to note for future
+   siblings, notes for the parent issue's AAR: No new sibling flags from this
+   slice. Parent #56 can close if no additional parent-level documentation/AAR
+   artifacts are outstanding.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/58-cli-prescribed-run-override/sub-issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/58-cli-prescribed-run-override/sub-issue.md
@@ -1,0 +1,286 @@
+# Sub-Issue #58 -- Wire the CLI Prescribed Run override
+
+Vertical slice for parent #56. Delivers the `run2max quantify` access surface
+for choosing an intended Prescribed Run and maps that CLI input to the existing
+`QuantifyOptions.prescribedRunOverride` contract from sub-issue #57.
+
+## Description
+
+Add a `quantify` CLI flag that lets a runner override Prescribed Run association
+when a Run moved dates or the default local-date match is ambiguous. The CLI
+parses a single selector value and passes a structured override into the engine;
+the engine remains responsible for finding a unique Prescribed Run or reporting
+an unavailable association.
+
+When `--prescribed-run` is supplied without `--plan`, the CLI should
+optimistically load `plan.yaml` from the current working directory. If no cwd
+Plan exists, fail clearly and tell the runner to pass `--plan <path>` for a Plan
+stored elsewhere. Normal `quantify` runs without `--prescribed-run` keep the
+existing silent Plan auto-discovery behavior.
+
+The planned flag is `--prescribed-run <selector>`. Selector rules are:
+
+- `YYYY-MM-DD` maps to `{ overrideDate: "YYYY-MM-DD" }`.
+- `date:YYYY-MM-DD` maps to `{ overrideDate: "YYYY-MM-DD" }`.
+- `label:<label>` maps to `{ overrideLabel: "<label>" }`.
+- Any other non-empty value maps to `{ overrideLabel: "<value>" }`.
+
+The `label:` prefix is the escape hatch for date-shaped labels such as
+`2026-05-12`. This keeps the common caller path short while avoiding an
+unresolvable ambiguity for labels that look like dates.
+
+Out of scope: changes to `findPrescribedRun`, Plan parsing, lap comparison,
+formatter output, unavailable reason prose, history artifact lookup, and any
+database/cache/config schema behavior.
+
+## Dependency classification
+
+| Dependency                                                     | Category            | Testing strategy                                                                                                                          |
+| -------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `citty` command argument handling                              | In-process          | Add the new command arg and test the parser/helper behavior with direct inputs; rely on existing command wiring patterns for `args` keys. |
+| CLI `quantify` command option construction                     | In-process          | Assert the parsed selector is included in the object passed to engine `quantify` when present and omitted when absent.                    |
+| `QuantifyOptions.prescribedRunOverride` from `@run2max/engine` | In-process          | Type-check the CLI mapping against the exported engine option shape and cover it through CLI tests/build.                                 |
+| `loadPlan` Plan discovery/loading behavior                     | Local-substitutable | Use temporary local fixtures or mocked loader behavior in CLI tests; when override is supplied, prefer `--plan`, then cwd `plan.yaml`, then fail clearly. |
+| Engine `quantify` behavior from sub-issue #57                  | In-process          | Do not retest association outcomes here; assert only that the CLI passes the structured override through.                                 |
+| Node filesystem reads for FIT/config/Plan/output files         | Local-substitutable | Existing command flow already uses local files; any new test should use temporary files or module mocks rather than real user paths.      |
+
+No remote-owned, collaborator-owned, true external, or irreplaceable dependency
+is introduced. No port is needed because this slice is a local CLI-to-engine
+option mapping with no second adapter.
+
+## Interface design
+
+The interface this sub-issue commits to is the CLI selector syntax and its
+mapping to `QuantifyOptions.prescribedRunOverride`. It does not add a new engine
+public API.
+
+### Design-it-twice
+
+**Alternative A -- Minimal direct engine flags**
+
+Expose the structured engine fields directly as two CLI flags.
+
+```ts
+args: {
+  "prescribed-run-date": { type: "string" },
+  "prescribed-run-label": { type: "string" },
+}
+
+// CLI mapping
+prescribedRunOverride: {
+  overrideDate: args["prescribed-run-date"],
+  overrideLabel: args["prescribed-run-label"],
+}
+```
+
+- Leverage: medium -- it exposes the full engine shape, including date and label
+  together, but makes the common moved-Run command longer.
+- Locality: high -- mapping is nearly mechanical and stays inside the CLI
+  command.
+- Testability: high -- each flag maps directly to one field.
+
+**Alternative B -- Single selector optimized for common caller**
+
+Expose one `--prescribed-run <selector>` flag. Date-shaped selectors map to an
+override date; other selectors map to an override label. Prefixes provide
+explicit typing when needed.
+
+```ts
+args: {
+  "prescribed-run": {
+    type: "string",
+    description:
+      "Prescribed Run override: YYYY-MM-DD, date:YYYY-MM-DD, label:<label>, or label text",
+  },
+}
+
+type CliPrescribedRunOverride =
+  | { overrideDate: string; overrideLabel?: never }
+  | { overrideLabel: string; overrideDate?: never };
+
+function parsePrescribedRunOverride(
+  value: string | undefined,
+): CliPrescribedRunOverride | undefined;
+```
+
+Example caller shape:
+
+```sh
+run2max quantify runs/wednesday.fit --prescribed-run "Tuesday Intervals"
+run2max quantify runs/wednesday.fit --prescribed-run 2026-05-12
+run2max quantify runs/wednesday.fit --plan . --prescribed-run label:2026-05-12
+```
+
+- Leverage: high -- one flag covers the normal date and label overrides while
+  preserving an escape hatch for date-shaped labels.
+- Locality: high -- all selector parsing lives in the CLI command before the
+  existing engine option boundary.
+- Testability: high -- parsing can be tested as a small pure helper, and command
+  tests only need to assert option pass-through.
+
+**Alternative C -- Explicit selector grammar only**
+
+Require every value to be typed with a prefix, such as `date:2026-05-12` or
+`label:Tuesday Intervals`, and reject bare values.
+
+```sh
+run2max quantify runs/wednesday.fit --plan . --prescribed-run date:2026-05-12
+run2max quantify runs/wednesday.fit --plan . --prescribed-run label:Tuesday Intervals
+```
+
+- Leverage: medium -- the syntax is unambiguous and extensible, but it makes the
+  common path more ceremony than this cycle needs.
+- Locality: high -- selector parsing remains local to the CLI command.
+- Testability: high -- invalid selectors are easy to reject deterministically.
+
+### Choice
+
+**B (single selector optimized for common caller).** It is the smallest user
+surface that supports moved Runs by date or label and still gives date-shaped
+labels an explicit `label:` escape hatch.
+
+A is rejected in one sentence: exposing two flags mirrors the engine but makes
+the common moved-Run command unnecessarily verbose. C is rejected in one
+sentence: requiring prefixes for every override optimizes for parser purity over
+the runner's most common command shape.
+
+### Public interface
+
+CLI entry point:
+
+```sh
+run2max quantify <fit-file> --prescribed-run <selector>
+run2max quantify <fit-file> --plan <plan-path-or-dir> --prescribed-run <selector>
+```
+
+Selector inputs:
+
+- Bare `YYYY-MM-DD`: authored Prescribed Run `localDate`.
+- `date:YYYY-MM-DD`: explicit authored Prescribed Run `localDate`.
+- `label:<label>`: exact authored Prescribed Run `label`, including labels that
+  look like dates.
+- Bare non-date text: exact authored Prescribed Run `label`.
+
+Engine output passed by the CLI:
+
+```ts
+prescribedRunOverride?: {
+  overrideDate?: string;
+  overrideLabel?: string;
+}
+```
+
+Invariants:
+
+- The CLI parser only chooses date versus label; it does not search the Plan.
+- Label matching remains exact and case-sensitive because the engine owns match
+  semantics.
+- The selector is passed only as structured engine input; the CLI does not call
+  `findPrescribedRun` directly.
+- `planContext` remains date-based. A cross-Week override must not redefine the
+  existing Week Plan Context.
+- A supplied override requires a loaded Plan. If `--plan` is absent, try
+  `plan.yaml` in the current working directory before failing.
+- Existing no-override Plan discovery remains unchanged and silent when no Plan
+  is found.
+- The CLI does not expose both `overrideDate` and `overrideLabel` simultaneously
+  in this slice. Ambiguity after a single selector remains an engine association
+  result for downstream comparison/formatting work.
+
+Error modes:
+
+- Blank `--prescribed-run` values fail with a CLI validation error.
+- `date:` with a non-`YYYY-MM-DD` value fails with a CLI validation error.
+- `label:` with an empty label fails with a CLI validation error.
+- Bare `YYYY-MM-DD` is treated as a date-shaped selector. To select a label with
+  that exact text, the runner must use `label:YYYY-MM-DD`.
+- A supplied override with no explicit Plan and no cwd `plan.yaml` fails with a
+  CLI validation error that tells the runner to pass `--plan <path>`.
+
+## Acceptance criteria
+
+- `run2max quantify` exposes `--prescribed-run <selector>` in
+  `packages/cli/src/commands/quantify.ts` help metadata.
+- Bare `YYYY-MM-DD` and `date:YYYY-MM-DD` selectors map to
+  `prescribedRunOverride.overrideDate`.
+- Bare non-date text and `label:<label>` selectors map to
+  `prescribedRunOverride.overrideLabel`.
+- `label:YYYY-MM-DD` is preserved as an override label, not coerced to an
+  override date.
+- Blank selector values, empty `label:` values, and malformed `date:` values
+  fail before calling engine `quantify`.
+- When `--prescribed-run` is supplied without `--plan`, the command attempts to
+  load `plan.yaml` from the current working directory before calling engine
+  `quantify`.
+- When `--prescribed-run` is supplied and neither `--plan` nor cwd `plan.yaml`
+  is available, the command fails before calling engine `quantify` with an error
+  that mentions no Plan was found in cwd and suggests `--plan <path>`.
+- When a Plan is loaded, the CLI passes the parsed override into
+  `quantify(..., { prescribedRunOverride })` without changing any other quantify
+  options.
+- Existing behavior without `--prescribed-run` remains unchanged; no override
+  field is passed unless the flag is supplied.
+- No changes are made to `findPrescribedRun`, `AnalysisResult`, formatter
+  output, lap comparison, history comparison, or Plan schema.
+- The parent issue and cycle PRD open question are updated at closure to record
+  the accepted `--prescribed-run` selector syntax.
+- Repository-runnable verification commands pass at closure, including
+  `pnpm test` and `pnpm build`.
+
+## Proposed tests
+
+1. **Bare date selector** -- parsing `2026-05-12` returns
+   `{ overrideDate: "2026-05-12" }`.
+2. **Explicit date selector** -- parsing `date:2026-05-12` returns
+   `{ overrideDate: "2026-05-12" }`.
+3. **Bare label selector** -- parsing `Tuesday Intervals` returns
+   `{ overrideLabel: "Tuesday Intervals" }`.
+4. **Explicit label selector** -- parsing `label:Tuesday Intervals` returns
+   `{ overrideLabel: "Tuesday Intervals" }`.
+5. **Date-shaped label selector** -- parsing `label:2026-05-12` returns
+   `{ overrideLabel: "2026-05-12" }`.
+6. **Malformed explicit date** -- parsing `date:Tuesday Intervals` fails with a
+   validation error.
+7. **Blank selector** -- blank or whitespace-only values fail with a validation
+   error.
+8. **CLI pass-through** -- a `quantify` command invocation with a loaded Plan
+   and `--prescribed-run` calls engine `quantify` with the parsed
+   `prescribedRunOverride`.
+9. **Cwd Plan fallback** -- a supplied `--prescribed-run` without `--plan` loads
+   `plan.yaml` from the current working directory and passes that Plan plus the
+   parsed override to engine `quantify`.
+10. **No Plan failure** -- a supplied `--prescribed-run` with neither explicit
+    Plan nor cwd `plan.yaml` fails before calling engine `quantify` and suggests
+    `--plan <path>`.
+11. **No flag unchanged** -- a normal `quantify` command invocation does not
+     pass `prescribedRunOverride`.
+12. **Build/type smoke** -- CLI build succeeds against the engine's exported
+     `QuantifyOptions` shape.
+
+## Affected artifacts
+
+- `packages/cli/src/commands/quantify.ts` -- add the CLI flag, selector parsing,
+  validation, no-Plan guard, and `quantify` option mapping.
+- `packages/cli/src/commands/quantify.test.ts` -- add focused tests for selector
+  parsing and command pass-through behavior. If direct command testing proves
+  too coupled, extract a small local helper from `quantify.ts` and test that
+  helper plus a narrow command smoke test.
+- `packages/cli/README.md` -- document the new `--prescribed-run` selector only
+  if the README lists `quantify` options today.
+- `context/cycles/02-run-prescriptions-and-comparisons/prd.md` -- mark the CLI
+  override open question resolved at sub-issue closure.
+- `context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md`
+  -- replace the carry-forward flag with closure notes once implemented.
+
+## Dependencies
+
+- Sub-issue #57 must remain closed and provides the existing structured engine
+  option `QuantifyOptions.prescribedRunOverride`.
+- Parent #56 remains the active parent scope for Prescribed Run association.
+- The CLI must prefer the parsed Plan loaded by `--plan`; when only
+  `--prescribed-run` is supplied, it may add the narrow cwd `plan.yaml` fallback
+  needed to avoid forcing `--plan .`.
+- The engine remains the source of truth for matching, ambiguity, and no-match
+  outcomes.
+- Do not add FIT lap comparison, formatter output, unavailable prose, history
+  artifact lookup, database/cache behavior, or config schema changes.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
@@ -40,9 +40,9 @@
   points at a Prescribed Run in a different Week from the captured Run's date,
   the Prescribed Run association reports the intended Prescribed Run's owning
   Week separately rather than silently redefining Plan Context.
-- The quantify access-surface override is not yet resolved. The first sub-issue
-  must confirm the exact CLI flag name and value shape before implementation,
-  then update this issue and the cycle PRD when approved.
+- The quantify access-surface override is not yet resolved. Follow-up sub-issue
+  #58 must confirm the exact CLI flag name and value shape before
+  implementation, then update this issue and the cycle PRD when approved.
 - Structured tests cover: default date match; no Prescribed Run on the Run date;
   duplicate Prescribed Runs on the date returning `ambiguous`; override by date;
   override by label; override with both date and label; override across a Week
@@ -55,9 +55,9 @@
 
 ## Implementation Approach
 
-1. Confirm the association interface in the first sub-issue before writing code.
-   The interface should stay in-process and operate on parsed Plan data, a Run
-   date, a timezone, and structured override options.
+1. Sub-issue #57 confirmed and implemented the association interface. The
+   interface stays in-process and operates on parsed Plan data, a Run date, a
+   timezone, and structured override options.
 2. Reuse `walkPlan` to traverse Weeks and reuse or extract the existing
    Run-to-Week local-date comparison from `associateRun`. Do not introduce a
    second Plan traversal abstraction.
@@ -65,19 +65,18 @@
    Default matching is local-date-to-current-Week; override matching searches
    the Plan for the intended Prescribed Run.
 4. Add engine tests for association outcomes before integrating with `quantify`.
-5. Add the minimal `QuantifyOptions` field needed to pass a structured override
-   into the engine after the access-surface decision is approved.
+5. Sub-issue #57 added the minimal `QuantifyOptions` field needed to pass a
+   structured override into the engine. Sub-issue #58 wires the approved CLI
+   access surface to that field.
 6. Integrate the association into `quantify` without changing the semantics of
    existing `planContext`.
 7. Export only the association entry point and public result types needed by
    downstream comparison work. Avoid formatter helpers and prescription-
    comparison output types in this parent.
 
-This parent is expected to close in one vertical slice if the first sub-issue
-can cover the pure association, quantify integration, and approved
-access-surface wiring together. If access-surface approval blocks
-implementation, split the pure engine association into the first sub-issue and
-defer CLI wiring to a sibling sub-issue.
+Sub-issue #57 closed the pure engine association and quantify-side structured
+override input. Because access-surface approval blocked CLI wiring, sub-issue
+#58 owns the remaining CLI flag syntax and option mapping.
 
 ## Dependencies
 
@@ -101,12 +100,11 @@ defer CLI wiring to a sibling sub-issue.
 
 - The cycle PRD's MUST RESOLVE question remains open until approved: "What exact
   CLI flag name and value shape should override the Prescribed Run association
-  during `quantify`?" Candidate design: a single `--prescribed-run <value>` flag
-  where `YYYY-MM-DD` is interpreted as an override date and other strings as an
-  override label. This is not accepted until explicitly greenlit.
-- If a single-string CLI flag is approved, document the date-shaped-label
-  ambiguity. A Prescribed Run label such as `2026-05-12` would be interpreted as
-  a date unless a separate label-specific flag is introduced.
+  during `quantify`?" Sub-issue #58 plans a single
+  `--prescribed-run <selector>` flag where bare `YYYY-MM-DD` and
+  `date:YYYY-MM-DD` map to an override date, while bare text and `label:<label>`
+  map to an override label. The `label:` prefix is the escape hatch for
+  date-shaped labels such as `2026-05-12`.
 - No lazy reparse: association uses `PrescribedRun.steps`; it does not inspect
   parser internals or reparse `PrescribedRun.prescription`.
 - Do not add lap comparison logic here. The match result provides the Prescribed
@@ -116,15 +114,14 @@ defer CLI wiring to a sibling sub-issue.
   alone.
 - Do not add history lookup or artifact comparison here. The Comparison Group is
   carried forward for downstream history work.
-- [ ] [57-engine-association-and-override -> sibling sub-issue TBD]
+- [ ] [58-cli-prescribed-run-override](58-cli-prescribed-run-override/sub-issue.md)
 
-  Sub-issue #57 closed the pure engine association and quantify-side structured
-  override input, but intentionally did not implement CLI access-surface wiring.
-  Create a sibling sub-issue to resolve and implement the quantify override flag
-  name/value shape, then map it to `QuantifyOptions.prescribedRunOverride`.
+  Resolve and implement the quantify CLI override flag name/value shape, then
+  map it to `QuantifyOptions.prescribedRunOverride`.
 
   Files to review:
   - context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/sub-issue.md
   - context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/aar.md
+  - context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/58-cli-prescribed-run-override/sub-issue.md
 
-  (See source AAR for full context)
+  (See source AAR for full #57 context)

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
@@ -1,0 +1,118 @@
+# Parent Issue #56 -- Run-to-Prescribed-Run Association
+
+> Technical execution doc. Sub-issues live in sibling `XX-...` folders.
+
+## Acceptance Criteria
+
+- The engine exposes a pure association entry point under the Plan area that
+  accepts parsed Plan data, a Run date, a timezone, and optional structured
+  override options. It returns either one matched Prescribed Run with its owning
+  Week context or a labeled unavailable result.
+- Default association converts the Run date to a local date using the supplied
+  timezone, finds the Week that contains that local date using the existing
+  Run-to-Week date logic, and searches only that Week's `prescribedRuns` for the
+  same `localDate`.
+- Default association succeeds only when exactly one Prescribed Run in the
+  date-matched Week has the matching `localDate`. Zero matches returns
+  `no_prescribed_run`; multiple matches returns `ambiguous`.
+- When the Run date falls outside every Week and no override is provided, the
+  association returns `no_week` without attempting a Prescribed Run lookup.
+- Explicit override options search the parsed Plan for the intended Prescribed
+  Run and are not constrained to the Week that contains the captured Run's date.
+  This supports moved Runs across Week boundaries.
+- Override by date matches Prescribed Runs whose `localDate` equals the override
+  date. Override by label matches Prescribed Runs whose `label` equals the
+  override label. Supplying both date and label requires both fields to match
+  the same Prescribed Run.
+- Override association succeeds only when exactly one Prescribed Run satisfies
+  the override. Zero matches returns `no_prescribed_run`; multiple matches
+  returns `ambiguous`.
+- The association result includes enough Week context for downstream comparison
+  and diagnostics: Week number, total Weeks, Week Type, Mesocycle name, Fractal
+  index, total Fractals, Week start, and the matched Prescribed Run.
+- The association result uses the already-expanded `PrescribedRun.steps` from
+  parent #53. It does not reparse `PrescribedRun.prescription`.
+- `quantify` integrates the association only when parsed Plan data is available.
+  The resulting `AnalysisResult` may expose a minimal `prescribedRunContext`
+  field, but this parent must not define the final prescription-comparison
+  output shape owned by downstream comparison and formatter parents.
+- The existing date-based `planContext` behavior remains intact. If an override
+  points at a Prescribed Run in a different Week from the captured Run's date,
+  the Prescribed Run association reports the intended Prescribed Run's owning
+  Week separately rather than silently redefining Plan Context.
+- The quantify access-surface override is not yet resolved. The first sub-issue
+  must confirm the exact CLI flag name and value shape before implementation,
+  then update this issue and the cycle PRD when approved.
+- Structured tests cover: default date match; no Prescribed Run on the Run date;
+  duplicate Prescribed Runs on the date returning `ambiguous`; override by date;
+  override by label; override with both date and label; override across a Week
+  boundary; override with no match; override with multiple matches; Run date
+  outside all Weeks without override; Plan with no `prescribedRuns`.
+- Existing Plan fixtures and tests pass without modification. Plans without
+  `prescribedRuns` remain valid and produce no Prescribed Run association.
+- Repository-runnable verification commands succeed at parent closure, including
+  `pnpm test` and package build/DTS checks already defined in the repository.
+
+## Implementation Approach
+
+1. Confirm the association interface in the first sub-issue before writing code.
+   The interface should stay in-process and operate on parsed Plan data, a Run
+   date, a timezone, and structured override options.
+2. Reuse `walkPlan` to traverse Weeks and reuse or extract the existing
+   Run-to-Week local-date comparison from `associateRun`. Do not introduce a
+   second Plan traversal abstraction.
+3. Implement default association and override association as one pure lookup.
+   Default matching is local-date-to-current-Week; override matching searches
+   the Plan for the intended Prescribed Run.
+4. Add engine tests for association outcomes before integrating with `quantify`.
+5. Add the minimal `QuantifyOptions` field needed to pass a structured override
+   into the engine after the access-surface decision is approved.
+6. Integrate the association into `quantify` without changing the semantics of
+   existing `planContext`.
+7. Export only the association entry point and public result types needed by
+   downstream comparison work. Avoid formatter helpers and prescription-
+   comparison output types in this parent.
+
+This parent is expected to close in one vertical slice if the first sub-issue
+can cover the pure association, quantify integration, and approved
+access-surface wiring together. If access-surface approval blocks
+implementation, split the pure engine association into the first sub-issue and
+defer CLI wiring to a sibling sub-issue.
+
+## Dependencies
+
+- Upstream: closed parent #53 provides Prescribed Run and Prescribed Step Plan
+  data, including expanded `PrescribedRun.steps`.
+- Upstream: cycle 01 parent #35 provides `walkPlan` and Week Context traversal.
+- Upstream: existing `associateRun` provides date-based Run-to-Week behavior for
+  Plan Context enrichment.
+- Downstream: lap-aligned step comparison consumes the matched Prescribed Run
+  and its owning Week context.
+- Downstream: prescription-comparison formatting consumes comparison results,
+  not the raw association result alone.
+- Downstream: comparable-history deltas consume the matched Prescribed Run's
+  Comparison Group.
+- External: no new persistence layer, database, config schema changes, zone
+  subsystem changes, external service calls, or history artifact reads.
+- Tooling: use repository-defined commands only. Existing `pnpm test` and
+  `pnpm build` scripts are sufficient for parent closure.
+
+## Flags
+
+- The cycle PRD's MUST RESOLVE question remains open until approved: "What exact
+  CLI flag name and value shape should override the Prescribed Run association
+  during `quantify`?" Candidate design: a single `--prescribed-run <value>` flag
+  where `YYYY-MM-DD` is interpreted as an override date and other strings as an
+  override label. This is not accepted until explicitly greenlit.
+- If a single-string CLI flag is approved, document the date-shaped-label
+  ambiguity. A Prescribed Run label such as `2026-05-12` would be interpreted as
+  a date unless a separate label-specific flag is introduced.
+- No lazy reparse: association uses `PrescribedRun.steps`; it does not inspect
+  parser internals or reparse `PrescribedRun.prescription`.
+- Do not add lap comparison logic here. The match result provides the Prescribed
+  Run and owning Week context; comparison happens downstream.
+- Do not add rendered formatter output here. Downstream formatter work should
+  render prescription-comparison results, not this parent-level association
+  alone.
+- Do not add history lookup or artifact comparison here. The Comparison Group is
+  carried forward for downstream history work.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
@@ -116,3 +116,15 @@ defer CLI wiring to a sibling sub-issue.
   alone.
 - Do not add history lookup or artifact comparison here. The Comparison Group is
   carried forward for downstream history work.
+- [ ] [57-engine-association-and-override -> sibling sub-issue TBD]
+
+  Sub-issue #57 closed the pure engine association and quantify-side structured
+  override input, but intentionally did not implement CLI access-surface wiring.
+  Create a sibling sub-issue to resolve and implement the quantify override flag
+  name/value shape, then map it to `QuantifyOptions.prescribedRunOverride`.
+
+  Files to review:
+  - context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/sub-issue.md
+  - context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/57-engine-association-and-override/aar.md
+
+  (See source AAR for full context)

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/issue.md
@@ -40,9 +40,11 @@
   points at a Prescribed Run in a different Week from the captured Run's date,
   the Prescribed Run association reports the intended Prescribed Run's owning
   Week separately rather than silently redefining Plan Context.
-- The quantify access-surface override is not yet resolved. Follow-up sub-issue
-  #58 must confirm the exact CLI flag name and value shape before
-  implementation, then update this issue and the cycle PRD when approved.
+- The quantify access-surface override is resolved in sub-issue #58:
+  `--prescribed-run <selector>` where bare `YYYY-MM-DD` and
+  `date:YYYY-MM-DD` map to override date, while bare text and `label:<label>`
+  map to override label. Without `--plan`, override mode first tries
+  `./plan.yaml` and fails clearly if no cwd Plan exists.
 - Structured tests cover: default date match; no Prescribed Run on the Run date;
   duplicate Prescribed Runs on the date returning `ambiguous`; override by date;
   override by label; override with both date and label; override across a Week
@@ -98,13 +100,12 @@ override input. Because access-surface approval blocked CLI wiring, sub-issue
 
 ## Flags
 
-- The cycle PRD's MUST RESOLVE question remains open until approved: "What exact
-  CLI flag name and value shape should override the Prescribed Run association
-  during `quantify`?" Sub-issue #58 plans a single
-  `--prescribed-run <selector>` flag where bare `YYYY-MM-DD` and
-  `date:YYYY-MM-DD` map to an override date, while bare text and `label:<label>`
-  map to an override label. The `label:` prefix is the escape hatch for
-  date-shaped labels such as `2026-05-12`.
+- Resolved by sub-issue #58: `quantify` uses
+  `--prescribed-run <selector>`. Bare `YYYY-MM-DD` and `date:YYYY-MM-DD` map to
+  override date; bare text and `label:<label>` map to override label. The
+  `label:` prefix is the escape hatch for date-shaped labels such as
+  `2026-05-12`. When override is supplied without `--plan`, CLI tries cwd
+  `plan.yaml` and fails clearly if absent.
 - No lazy reparse: association uses `PrescribedRun.steps`; it does not inspect
   parser internals or reparse `PrescribedRun.prescription`.
 - Do not add lap comparison logic here. The match result provides the Prescribed
@@ -114,7 +115,11 @@ override input. Because access-surface approval blocked CLI wiring, sub-issue
   alone.
 - Do not add history lookup or artifact comparison here. The Comparison Group is
   carried forward for downstream history work.
-- [ ] [58-cli-prescribed-run-override](58-cli-prescribed-run-override/sub-issue.md)
+- [x] [58-cli-prescribed-run-override](58-cli-prescribed-run-override/sub-issue.md)
+
+  Closed: implemented CLI selector parsing/validation, cwd `plan.yaml` fallback
+  for override mode, no-Plan failure messaging, and `QuantifyOptions`
+  pass-through mapping.
 
   Resolve and implement the quantify CLI override flag name/value shape, then
   map it to `QuantifyOptions.prescribedRunOverride`.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/sub-prd.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/56-run-prescription-association/sub-prd.md
@@ -1,0 +1,78 @@
+# Parent Issue #56 -- Run-to-Prescribed-Run Association
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## Scope
+
+When a runner quantifies a captured Run against a Plan, Run2Max needs to identify
+the intended Prescribed Run before any lap-aligned comparison can happen.
+Default association uses the Run's local date. Explicit override support lets a
+runner point comparison at the intended Prescribed Run when the Run moved or the
+date match is ambiguous.
+
+This parent stops at producing a structured association result. It does not
+compare FIT laps to Prescribed Steps, render prescription-comparison output, or
+compute comparable-history deltas.
+
+## Owned user stories
+
+From the cycle PRD:
+
+- As a runner quantifying a FIT File from a planned interval day, I see whether
+  the captured lap sequence matched the Prescribed Run, so I can review the Run
+  against what I intended to execute.
+  > This parent owns only the association that enables the later lap comparison.
+
+- As a runner who moves Tuesday's planned Run to Wednesday, I can override the
+  Prescribed Run association, so comparison follows intent rather than calendar
+  accident.
+
+- As a maintainer adding the feature, I can test association through structured
+  data, so output wording changes do not break the behavior contract.
+
+## Encounter Statements
+
+- A runner running `run2max quantify path/to/run.fit --plan . --format yaml`
+  eventually sees a prescription-comparison section only when a Prescribed Run
+  has been associated. This parent produces the association input for that later
+  section; it does not render the section.
+
+- A runner with a moved Run needs a simple explicit override at the quantify
+  access surface. The exact flag name and value shape remain a decision to make
+  before implementation, not a decision closed by this sub-PRD.
+
+- A maintainer opening the association code first sees a pure lookup over parsed
+  Plan data that returns a matched Prescribed Run with its owning Week context or
+  a labeled unavailable reason.
+
+## Directional Dependencies
+
+- Upstream: closed parent #53 delivers Prescribed Run, Prescribed Step, Target
+  Range, `prescribedRuns` on each Week, and expanded `PrescribedRun.steps`.
+- Upstream: cycle 01 parent #35 delivers `walkPlan` and Week Context traversal;
+  this parent must reuse that seam rather than create a second Plan traversal.
+- Upstream: existing Run-to-Week association already provides local-date Week
+  matching for Plan Context enrichment.
+- Downstream: lap-aligned step comparison consumes the matched Prescribed Run and
+  its expanded Prescribed Steps.
+- Downstream: formatter output consumes comparison data created after this
+  association, not the association result alone.
+- Downstream: comparable-history deltas consume the matched Prescribed Run's
+  Comparison Group.
+
+## Domain Language
+
+No new domain terms are introduced. This parent uses existing glossary terms:
+**Prescribed Run**, **Prescribed Step**, **Week**, **Plan**, **Run**, **FIT
+File**, **Quantify**, **Plan Context**, and **Comparison Group**.
+
+Boundary scenarios checked against `context/ubiquitous-language.md`:
+
+- Before a FIT File exists, the planned unit is a **Prescribed Run**, not a
+  **Run**.
+- A **Run** is associated with at most one **Prescribed Run** for comparison,
+  normally by local date with an explicit override for moved or ambiguous Runs.
+- An explicit override follows the runner's intended **Prescribed Run**; it must
+  not be limited to the Week that contains the captured Run's date.

--- a/context/cycles/02-run-prescriptions-and-comparisons/prd.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/prd.md
@@ -166,8 +166,10 @@ prior Runs in the same Comparison Group.
 
 ## Open questions
 
-- MUST RESOLVE: What exact CLI flag name and value shape should override the
-  Prescribed Run association during `quantify`?
+- Resolved during parent #56: `quantify` override uses
+  `--prescribed-run <selector>`. Bare `YYYY-MM-DD` and `date:YYYY-MM-DD` select
+  by Prescribed Run local date; bare text and `label:<label>` select by label.
+  `label:` is the escape hatch for date-shaped labels.
 - MUST RESOLVE: What detailed-profile marker or validation rule proves a saved
   YAML/JSON artifact is detailed enough for history comparison?
 - RESOLVE THROUGH IMPLEMENTATION: Exact structured output shape for the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,6 +59,9 @@ run2max quantify my-run.fit --timezone America/Santiago   # IANA tz override
 run2max quantify my-run.fit --downsample 10               # 1 record per 10s
 run2max quantify my-run.fit --exclude-anomalies           # null out bad values
 run2max quantify my-run.fit --config ./run2max.config.yaml
+run2max quantify my-run.fit --prescribed-run 2026-05-12
+run2max quantify my-run.fit --prescribed-run "Tuesday Intervals"
+run2max quantify my-run.fit --prescribed-run label:2026-05-12
 ```
 
 ## All flags
@@ -78,6 +81,7 @@ run2max quantify my-run.fit --config ./run2max.config.yaml
 | `--exclude-anomalies` | —     | `false` | Exclude anomalous values from aggregations                                                          |
 | `--no-weather`        | —     | `false` | Skip weather fetch for this run                                                                     |
 | `--plan`              | —     | —       | Path to `plan.yaml` or its directory (auto-discovered from the `.fit` file's directory when absent) |
+| `--prescribed-run`    | —     | —       | Override prescribed-run association: `YYYY-MM-DD`, `date:YYYY-MM-DD`, `label:<label>`, or label text |
 
 ## Plan commands
 

--- a/packages/cli/src/commands/quantify.test.ts
+++ b/packages/cli/src/commands/quantify.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockLoadConfig,
+  mockLoadPlan,
+  mockQuantify,
+  mockFormatResult,
+  mockReadFile,
+  mockStat,
+  mockWriteFile,
+} = vi.hoisted(() => ({
+  mockLoadConfig: vi.fn(),
+  mockLoadPlan: vi.fn(),
+  mockQuantify: vi.fn(),
+  mockFormatResult: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+  mockWriteFile: vi.fn(),
+}));
+
+vi.mock("@run2max/engine", () => ({
+  loadConfig: mockLoadConfig,
+  loadPlan: mockLoadPlan,
+  quantify: mockQuantify,
+  formatResult: mockFormatResult,
+  DEFAULT_PROFILE: { sections: [], columns: [] },
+  scanBlockRuns: vi.fn().mockResolvedValue([]),
+  detectWeekDeviations: vi.fn(),
+  reportHasAnomalies: vi.fn().mockReturnValue(false),
+  walkPlan: vi.fn().mockReturnValue([]),
+  addDays: vi.fn().mockReturnValue("2099-01-08"),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mockReadFile,
+  stat: mockStat,
+  writeFile: mockWriteFile,
+}));
+
+import command, { parsePrescribedRunOverride } from "./quantify.js";
+
+describe("quantify command prescribed-run override", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockReadFile.mockResolvedValue(Buffer.from([0x00]));
+    mockLoadConfig.mockResolvedValue(null);
+    mockLoadPlan.mockResolvedValue({ block: "Build" });
+    mockQuantify.mockResolvedValue({ planContext: undefined });
+    mockFormatResult.mockReturnValue({ output: "ok", warnings: [] });
+
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("maps explicit date selector to overrideDate", () => {
+    expect(parsePrescribedRunOverride("date:2026-05-12")).toEqual({
+      overrideDate: "2026-05-12",
+    });
+  });
+
+  it("maps bare label selector to overrideLabel", () => {
+    expect(parsePrescribedRunOverride("Tuesday Intervals")).toEqual({
+      overrideLabel: "Tuesday Intervals",
+    });
+  });
+
+  it("maps explicit label selector to overrideLabel", () => {
+    expect(parsePrescribedRunOverride("label:Tuesday Intervals")).toEqual({
+      overrideLabel: "Tuesday Intervals",
+    });
+  });
+
+  it("keeps label:YYYY-MM-DD as overrideLabel", () => {
+    expect(parsePrescribedRunOverride("label:2026-05-12")).toEqual({
+      overrideLabel: "2026-05-12",
+    });
+  });
+
+  it("throws for malformed date: selector", () => {
+    expect(() => parsePrescribedRunOverride("date:Tuesday")).toThrow(
+      "--prescribed-run date: must use YYYY-MM-DD",
+    );
+  });
+
+  it("throws for blank selector", () => {
+    expect(() => parsePrescribedRunOverride("   ")).toThrow(
+      "--prescribed-run cannot be blank",
+    );
+  });
+
+  it("throws for empty label: selector", () => {
+    expect(() => parsePrescribedRunOverride("label:  ")).toThrow(
+      "--prescribed-run label: must include a label",
+    );
+  });
+
+  it("maps bare date selector to overrideDate in quantify options", async () => {
+    await command.run?.({
+      args: {
+        file: "/tmp/run.fit",
+        format: "md",
+        "exclude-anomalies": false,
+        "no-weather": false,
+        "prescribed-run": "2026-05-12",
+      },
+    });
+
+    expect(mockQuantify).toHaveBeenCalledTimes(1);
+    expect(mockQuantify.mock.calls[0]?.[1]).toMatchObject({
+      prescribedRunOverride: { overrideDate: "2026-05-12" },
+    });
+  });
+
+  it("passes cwd plan fallback when override is supplied without --plan", async () => {
+    await command.run?.({
+      args: {
+        file: "/tmp/run.fit",
+        format: "md",
+        "exclude-anomalies": false,
+        "no-weather": false,
+        "prescribed-run": "Tuesday Intervals",
+      },
+    });
+
+    expect(mockLoadPlan).toHaveBeenCalledWith(`${process.cwd()}/plan.yaml`);
+    expect(mockQuantify.mock.calls[0]?.[1]).toMatchObject({
+      prescribedRunOverride: { overrideLabel: "Tuesday Intervals" },
+      plan: { block: "Build" },
+    });
+  });
+
+  it("fails before quantify when override is supplied and cwd plan is missing", async () => {
+    mockLoadPlan.mockRejectedValueOnce(new Error("missing"));
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: string | number | null | undefined) => {
+        throw new Error(`EXIT:${code}`);
+      }) as never);
+
+    await expect(
+      command.run?.({
+        args: {
+          file: "/tmp/run.fit",
+          format: "md",
+          "exclude-anomalies": false,
+          "no-weather": false,
+          "prescribed-run": "Tuesday Intervals",
+        },
+      }),
+    ).rejects.toThrow("EXIT:1");
+
+    expect(mockQuantify).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("No plan.yaml found in the current working directory"),
+    );
+  });
+
+  it("does not pass prescribedRunOverride when flag is absent", async () => {
+    await command.run?.({
+      args: {
+        file: "/tmp/run.fit",
+        format: "md",
+        "exclude-anomalies": false,
+        "no-weather": false,
+      },
+    });
+
+    expect(mockQuantify).toHaveBeenCalledTimes(1);
+    expect(mockQuantify.mock.calls[0]?.[1]).not.toHaveProperty(
+      "prescribedRunOverride",
+    );
+  });
+});

--- a/packages/cli/src/commands/quantify.ts
+++ b/packages/cli/src/commands/quantify.ts
@@ -31,6 +31,44 @@ function toArrayBuffer(buffer: Buffer): ArrayBuffer {
   ) as ArrayBuffer;
 }
 
+const LOCAL_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parsePrescribedRunOverride(selector: string | undefined):
+  | { overrideDate: string }
+  | { overrideLabel: string }
+  | undefined {
+  if (selector === undefined) return undefined;
+
+  const value = selector.trim();
+  if (value.length === 0) {
+    throw new Error("--prescribed-run cannot be blank");
+  }
+
+  if (value.startsWith("date:")) {
+    const dateValue = value.slice("date:".length).trim();
+    if (!LOCAL_DATE_RE.test(dateValue)) {
+      throw new Error("--prescribed-run date: must use YYYY-MM-DD");
+    }
+    return { overrideDate: dateValue };
+  }
+
+  if (value.startsWith("label:")) {
+    const labelValue = value.slice("label:".length).trim();
+    if (labelValue.length === 0) {
+      throw new Error("--prescribed-run label: must include a label");
+    }
+    return { overrideLabel: labelValue };
+  }
+
+  if (LOCAL_DATE_RE.test(value)) {
+    return { overrideDate: value };
+  }
+
+  return {
+    overrideLabel: value,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Command
 // ---------------------------------------------------------------------------
@@ -110,6 +148,11 @@ export default defineCommand({
       type: "string",
       description:
         "Path to plan.yaml or directory containing plan.yaml. Auto-discovered from the .fit file's directory when absent.",
+    },
+    "prescribed-run": {
+      type: "string",
+      description:
+        "Prescribed Run override: YYYY-MM-DD, date:YYYY-MM-DD, label:<label>, or label text",
     },
   },
 
@@ -200,6 +243,15 @@ export default defineCommand({
 
     // ---- Resolve timezone
     const timezone = args.timezone ?? config?.athlete?.timezone;
+    let prescribedRunOverride:
+      | { overrideDate: string }
+      | { overrideLabel: string }
+      | undefined;
+    try {
+      prescribedRunOverride = parsePrescribedRunOverride(args["prescribed-run"]);
+    } catch (err) {
+      fatal((err as Error).message);
+    }
 
     // ---- Discover and load plan.yaml (silent when absent)
     const fitDir = resolve(dirname(args.file));
@@ -218,6 +270,15 @@ export default defineCommand({
         plan = await loadPlan(planPath!);
       } catch (err) {
         fatal(`Could not load plan: ${(err as Error).message}`);
+      }
+    } else if (prescribedRunOverride) {
+      const cwdPlanPath = join(process.cwd(), "plan.yaml");
+      try {
+        plan = await loadPlan(cwdPlanPath);
+      } catch {
+        fatal(
+          "No plan.yaml found in the current working directory. --prescribed-run requires a Plan; pass --plan <path> to use a Plan in another location.",
+        );
       }
     } else {
       // Auto-discover plan.yaml in the same directory as the .fit file
@@ -243,6 +304,7 @@ export default defineCommand({
         excludeAnomalies: args["exclude-anomalies"],
         noWeather: args["no-weather"],
         plan,
+        ...(prescribedRunOverride ? { prescribedRunOverride } : {}),
         fitDirPath: fitDir,
       });
     } catch (err) {

--- a/packages/engine/src/computations/quantify.test.ts
+++ b/packages/engine/src/computations/quantify.test.ts
@@ -13,6 +13,7 @@ vi.mock("normalize-fit-file", () => ({
 
 import { parseFitBuffer, normalizeFFP } from "normalize-fit-file";
 import { quantify } from "./quantify.js";
+import { parsePlan } from "../plan/schema.js";
 
 const BASE_TIME = new Date("2026-04-12T08:00:00Z");
 function ms(seconds: number): Date {
@@ -61,6 +62,56 @@ function buildNormalizedData(recordCount: number) {
     ],
     records,
   };
+}
+
+function makePlanWithPrescribedRuns(options?: {
+  firstWeekDate?: string;
+  secondWeekDate?: string;
+}) {
+  const firstWeekDate = options?.firstWeekDate ?? "2026-04-12";
+  const secondWeekDate = options?.secondWeekDate ?? "2026-04-13";
+
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Santiago",
+    start: "2026-04-06",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              {
+                planned: "L",
+                start: "2026-04-06",
+                prescribed_runs: [
+                  {
+                    local_date: firstWeekDate,
+                    label: "Sunday Endurance",
+                    prescription: "30min @ E",
+                    comparison_group: "endurance",
+                  },
+                ],
+              },
+              {
+                planned: "LL",
+                start: "2026-04-13",
+                prescribed_runs: [
+                  {
+                    local_date: secondWeekDate,
+                    label: "Monday Tempo",
+                    prescription: "20min @ M[251-260W]",
+                    comparison_group: "tempo",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
 }
 
 const CONFIG: Run2MaxConfig = {
@@ -188,5 +239,62 @@ describe("quantify", () => {
     expect(result.segments).toEqual([]);
     expect(result.zoneDistribution).toEqual([]);
     expect(result.kmSplits.length).toBeGreaterThan(0); // km splits don't require zones
+  });
+
+  it("adds prescribedRunContext when a prescribed run matches by date", async () => {
+    const normalized = buildNormalizedData(20);
+    vi.mocked(parseFitBuffer).mockResolvedValue({} as never);
+    vi.mocked(normalizeFFP).mockReturnValue(normalized as never);
+
+    const plan = makePlanWithPrescribedRuns();
+    const result = await quantify(new ArrayBuffer(0), {
+      config: CONFIG,
+      plan,
+      timezone: "UTC",
+    });
+
+    expect(result.prescribedRunContext).toBeDefined();
+    expect(result.prescribedRunContext?.matchKind).toBe("date");
+    expect(result.prescribedRunContext?.label).toBe("Sunday Endurance");
+    expect(result.prescribedRunContext?.localDate).toBe("2026-04-12");
+    expect(result.prescribedRunContext?.weekNumber).toBe(1);
+  });
+
+  it("keeps prescribedRunContext undefined when no prescribed run matches", async () => {
+    const normalized = buildNormalizedData(20);
+    vi.mocked(parseFitBuffer).mockResolvedValue({} as never);
+    vi.mocked(normalizeFFP).mockReturnValue(normalized as never);
+
+    const plan = makePlanWithPrescribedRuns({ firstWeekDate: "2026-04-11" });
+    const result = await quantify(new ArrayBuffer(0), {
+      config: CONFIG,
+      plan,
+      timezone: "UTC",
+    });
+
+    expect(result.planContext).toBeDefined();
+    expect(result.planContext?.weekNumber).toBe(1);
+    expect(result.prescribedRunContext).toBeUndefined();
+  });
+
+  it("supports cross-week prescribed run override while preserving date-based planContext", async () => {
+    const normalized = buildNormalizedData(20);
+    vi.mocked(parseFitBuffer).mockResolvedValue({} as never);
+    vi.mocked(normalizeFFP).mockReturnValue(normalized as never);
+
+    const plan = makePlanWithPrescribedRuns();
+    const result = await quantify(new ArrayBuffer(0), {
+      config: CONFIG,
+      plan,
+      timezone: "UTC",
+      prescribedRunOverride: { overrideDate: "2026-04-13" },
+    });
+
+    expect(result.planContext).toBeDefined();
+    expect(result.planContext?.weekNumber).toBe(1);
+    expect(result.prescribedRunContext).toBeDefined();
+    expect(result.prescribedRunContext?.matchKind).toBe("override");
+    expect(result.prescribedRunContext?.label).toBe("Monday Tempo");
+    expect(result.prescribedRunContext?.weekNumber).toBe(2);
   });
 });

--- a/packages/engine/src/computations/quantify.ts
+++ b/packages/engine/src/computations/quantify.ts
@@ -6,6 +6,7 @@ import {
 import type {
   AnalysisResult,
   PlanContext,
+  PrescribedRunContext,
   QuantifyOptions,
   Run2MaxRecord,
   WeatherSummary,
@@ -14,7 +15,7 @@ import type {
   KmSplitRow,
 } from "../types.js";
 import { ENGINE_VERSION } from "../index.js";
-import { associateRun, scanBlockRuns } from "../plan/associate.js";
+import { associateRun, findPrescribedRun, scanBlockRuns } from "../plan/associate.js";
 import { detectCapabilities } from "../detect-capabilities.js";
 import { detectAnomalies, applyAnomalyExclusions } from "./anomalies.js";
 import { computeSummary } from "./summary.js";
@@ -140,8 +141,34 @@ export async function quantify(
 
   // 9. Plan context (optional — only when options.plan is provided)
   let planContext: PlanContext | undefined;
+  let prescribedRunContext: PrescribedRunContext | undefined;
   if (options.plan) {
     const timezone = options.timezone ?? config?.athlete?.timezone ?? "UTC";
+    const prescribedAssoc = findPrescribedRun(
+      options.plan,
+      summary.date,
+      timezone,
+      options.prescribedRunOverride,
+    );
+
+    if (prescribedAssoc.ok) {
+      const { prescribedRun, weekContext, matchKind } = prescribedAssoc.match;
+      prescribedRunContext = {
+        label: prescribedRun.label,
+        localDate: prescribedRun.localDate,
+        comparisonGroup: prescribedRun.comparisonGroup,
+        steps: prescribedRun.steps,
+        matchKind,
+        weekNumber: weekContext.absoluteIndex,
+        totalWeeks: weekContext.totalWeeks,
+        weekType: weekContext.week.planned,
+        mesocycle: weekContext.mesocycleName,
+        fractalIndex: weekContext.fractalIndex + 1,
+        totalFractals: weekContext.totalFractals,
+        weekStart: weekContext.week.start,
+      };
+    }
+
     const weekAssoc = associateRun(options.plan, summary.date, timezone);
 
     if (weekAssoc) {
@@ -212,5 +239,6 @@ export async function quantify(
     anomalies,
     capabilities,
     planContext,
+    prescribedRunContext,
   };
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -33,7 +33,13 @@ export { walkPlan } from "./plan/walk.js";
 // Runs and capture
 // ---------------------------------------------------------------------------
 
-export { scanBlockRuns } from "./plan/associate.js";
+export { scanBlockRuns, findPrescribedRun } from "./plan/associate.js";
+export type {
+  FindPrescribedRunOptions,
+  FindPrescribedRunReason,
+  FindPrescribedRunResult,
+  PrescribedRunMatch,
+} from "./plan/associate.js";
 
 // ---------------------------------------------------------------------------
 // Metrics and zones

--- a/packages/engine/src/plan/associate.test.ts
+++ b/packages/engine/src/plan/associate.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parsePlan } from "./schema.js";
-import { associateRun, scanBlockRuns, extractDisplayName } from "./associate.js";
+import { associateRun, findPrescribedRun, scanBlockRuns, extractDisplayName } from "./associate.js";
 
 // ---------------------------------------------------------------------------
 // Shared test fixture
@@ -53,6 +53,96 @@ function makePlan() {
           {
             weeks: [
               { planned: "P", start: "2026-07-06" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function makePlanWithPrescribedRuns() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Santiago",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              {
+                planned: "L",
+                start: "2026-05-04",
+                prescribed_runs: [
+                  {
+                    local_date: "2026-05-06",
+                    label: "Tuesday Intervals",
+                    prescription: "3min @ SUB-T[260-280W]",
+                    comparison_group: "sub-t-3min",
+                  },
+                ],
+              },
+              { planned: "LL", start: "2026-05-11" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function makePlanForAssociationCases() {
+  return parsePlan({
+    schema_version: 1,
+    block: "build",
+    goal: "Half Marathon Santiago",
+    start: "2026-05-04",
+    mesocycles: [
+      {
+        name: "CANAL",
+        fractals: [
+          {
+            weeks: [
+              {
+                planned: "L",
+                start: "2026-05-04",
+                prescribed_runs: [
+                  {
+                    local_date: "2026-05-06",
+                    label: "Tuesday Intervals A",
+                    prescription: "3min @ SUB-T[260-280W]",
+                  },
+                  {
+                    local_date: "2026-05-06",
+                    label: "Tuesday Intervals B",
+                    prescription: "3min @ SUB-T[260-280W]",
+                  },
+                  {
+                    local_date: "2026-05-08",
+                    label: "Friday Tempo",
+                    prescription: "20min @ M[251-260W]",
+                  },
+                ],
+              },
+              {
+                planned: "LL",
+                start: "2026-05-11",
+                prescribed_runs: [
+                  {
+                    local_date: "2026-05-13",
+                    label: "Wednesday Intervals",
+                    prescription: "4min @ SUB-T[260-280W]",
+                  },
+                  {
+                    local_date: "2026-05-14",
+                    label: "Wednesday Intervals",
+                    prescription: "5min @ SUB-T[260-280W]",
+                  },
+                ],
+              },
             ],
           },
         ],
@@ -149,6 +239,144 @@ describe("associateRun", () => {
 
     expect(result).not.toBeNull();
     expect(result!.weekStart).toBe("2026-06-15");
+  });
+});
+
+describe("findPrescribedRun", () => {
+  it("matches one prescribed run by local date in the date-matched week", () => {
+    const plan = makePlanWithPrescribedRuns();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-06T12:00:00Z"),
+      "UTC",
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.match.matchKind).toBe("date");
+      expect(result.match.prescribedRun.label).toBe("Tuesday Intervals");
+      expect(result.match.prescribedRun.localDate).toBe("2026-05-06");
+      expect(result.match.weekContext.absoluteIndex).toBe(1);
+    }
+  });
+
+  it("returns no_week when run date is outside the plan and no override is supplied", () => {
+    const plan = makePlanWithPrescribedRuns();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-04-01T12:00:00Z"),
+      "UTC",
+    );
+
+    expect(result).toEqual({ ok: false, reason: "no_week" });
+  });
+
+  it("returns no_prescribed_run when week matches but no prescribed run has the same local date", () => {
+    const plan = makePlanWithPrescribedRuns();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-07T12:00:00Z"),
+      "UTC",
+    );
+
+    expect(result).toEqual({ ok: false, reason: "no_prescribed_run" });
+  });
+
+  it("returns ambiguous when multiple prescribed runs share the same local date in the matched week", () => {
+    const plan = makePlanForAssociationCases();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-06T12:00:00Z"),
+      "UTC",
+    );
+
+    expect(result).toEqual({ ok: false, reason: "ambiguous" });
+  });
+
+  it("matches by overrideDate across week boundaries", () => {
+    const plan = makePlanForAssociationCases();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-14T12:00:00Z"),
+      "UTC",
+      { overrideDate: "2026-05-08" },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.match.matchKind).toBe("override");
+      expect(result.match.prescribedRun.label).toBe("Friday Tempo");
+      expect(result.match.weekContext.week.start).toBe("2026-05-04");
+    }
+  });
+
+  it("matches by overrideLabel across week boundaries", () => {
+    const plan = makePlanForAssociationCases();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-08T12:00:00Z"),
+      "UTC",
+      { overrideLabel: "Tuesday Intervals B" },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.match.matchKind).toBe("override");
+      expect(result.match.prescribedRun.localDate).toBe("2026-05-06");
+      expect(result.match.weekContext.week.start).toBe("2026-05-04");
+    }
+  });
+
+  it("requires overrideDate and overrideLabel to match the same prescribed run", () => {
+    const plan = makePlanForAssociationCases();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-08T12:00:00Z"),
+      "UTC",
+      {
+        overrideDate: "2026-05-08",
+        overrideLabel: "Tuesday Intervals A",
+      },
+    );
+
+    expect(result).toEqual({ ok: false, reason: "no_prescribed_run" });
+  });
+
+  it("returns ambiguous when override matches multiple prescribed runs", () => {
+    const plan = makePlanForAssociationCases();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2026-05-08T12:00:00Z"),
+      "UTC",
+      { overrideLabel: "Wednesday Intervals" },
+    );
+
+    expect(result).toEqual({ ok: false, reason: "ambiguous" });
+  });
+
+  it("can match override even when run date falls outside every week", () => {
+    const plan = makePlanForAssociationCases();
+
+    const result = findPrescribedRun(
+      plan,
+      new Date("2027-01-01T12:00:00Z"),
+      "UTC",
+      { overrideDate: "2026-05-08" },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.match.prescribedRun.label).toBe("Friday Tempo");
+      expect(result.match.matchKind).toBe("override");
+    }
   });
 });
 

--- a/packages/engine/src/plan/associate.ts
+++ b/packages/engine/src/plan/associate.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { parseFitBuffer, normalizeFFP } from "normalize-fit-file";
 import type { Plan } from "./types.js";
 import { addDays } from "./dates.js";
-import { walkPlan } from "./walk.js";
+import { walkPlan, type WeekContext } from "./walk.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,6 +25,26 @@ export interface BlockRun {
   displayName: string;
   date: Date;
 }
+
+export interface FindPrescribedRunOptions {
+  overrideDate?: string;
+  overrideLabel?: string;
+}
+
+export type FindPrescribedRunReason =
+  | "no_week"
+  | "no_prescribed_run"
+  | "ambiguous";
+
+export interface PrescribedRunMatch {
+  prescribedRun: NonNullable<WeekContext["week"]["prescribedRuns"]>[number];
+  weekContext: WeekContext;
+  matchKind: "date" | "override";
+}
+
+export type FindPrescribedRunResult =
+  | { ok: true; match: PrescribedRunMatch }
+  | { ok: false; reason: FindPrescribedRunReason };
 
 /**
  * Converts a UTC Date to a local ISO date string (YYYY-MM-DD) in the given
@@ -96,6 +116,73 @@ export function associateRun(
   }
 
   return null;
+}
+
+export function findPrescribedRun(
+  plan: Plan,
+  runDate: Date,
+  timezone: string,
+  options?: FindPrescribedRunOptions,
+): FindPrescribedRunResult {
+  const localDate = toLocalDate(runDate, timezone);
+  const flatWeeks = walkPlan(plan);
+
+  const hasOverride = Boolean(options?.overrideDate || options?.overrideLabel);
+
+  if (hasOverride) {
+    const matches: PrescribedRunMatch[] = [];
+
+    for (const weekContext of flatWeeks) {
+      const runs = weekContext.week.prescribedRuns ?? [];
+      for (const prescribedRun of runs) {
+        if (options?.overrideDate && prescribedRun.localDate !== options.overrideDate) {
+          continue;
+        }
+        if (options?.overrideLabel && prescribedRun.label !== options.overrideLabel) {
+          continue;
+        }
+        matches.push({ prescribedRun, weekContext, matchKind: "override" });
+      }
+    }
+
+    if (matches.length === 1) {
+      return { ok: true, match: matches[0]! };
+    }
+    if (matches.length > 1) {
+      return { ok: false, reason: "ambiguous" };
+    }
+    return { ok: false, reason: "no_prescribed_run" };
+  }
+
+  const weekContext = flatWeeks.find((ctx) => {
+    const weekEnd = addDays(ctx.week.start, 7);
+    return localDate >= ctx.week.start && localDate < weekEnd;
+  });
+
+  if (!weekContext) {
+    return { ok: false, reason: "no_week" };
+  }
+
+  const matches = (weekContext.week.prescribedRuns ?? []).filter(
+    (run) => run.localDate === localDate,
+  );
+
+  if (matches.length === 1) {
+    return {
+      ok: true,
+      match: {
+        prescribedRun: matches[0]!,
+        weekContext,
+        matchKind: "date",
+      },
+    };
+  }
+
+  if (matches.length > 1) {
+    return { ok: false, reason: "ambiguous" };
+  }
+
+  return { ok: false, reason: "no_prescribed_run" };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,6 +1,6 @@
 import type { RecordData } from "normalize-fit-file";
 import type { Run2MaxConfig } from "./config/schema.js";
-import type { Plan } from "./plan/types.js";
+import type { Plan, PrescribedStep } from "./plan/types.js";
 export type { Run2MaxConfig, ZoneConfig, OutputProfileConfig } from "./config/schema.js";
 
 // ---------------------------------------------------------------------------
@@ -63,6 +63,11 @@ export interface QuantifyOptions {
   noWeather?: boolean;  // CLI --no-weather flag; overrides config.weather
   /** Parsed plan.yaml for periodization context enrichment. */
   plan?: Plan;
+  /** Structured override for Prescribed Run association. */
+  prescribedRunOverride?: {
+    overrideDate?: string;
+    overrideLabel?: string;
+  };
   /**
    * Directory containing .fit files for this training block.
    * Used to count completed runs in the current week.
@@ -238,6 +243,8 @@ export interface AnalysisResult {
   capabilities: DataCapabilities;
   /** Periodization context from plan.yaml. Undefined when no plan is present. */
   planContext?: PlanContext;
+  /** Matched Prescribed Run context when association succeeds. */
+  prescribedRunContext?: PrescribedRunContext;
 }
 
 // ---------------------------------------------------------------------------
@@ -258,6 +265,21 @@ export interface PlanContext {
     expected: number;
     runs: string[];
   };
+}
+
+export interface PrescribedRunContext {
+  label: string;
+  localDate: string;
+  comparisonGroup?: string;
+  steps: PrescribedStep[];
+  matchKind: "date" | "override";
+  weekNumber: number;
+  totalWeeks: number;
+  weekType: string;
+  mesocycle: string;
+  fractalIndex: number;
+  totalFractals: number;
+  weekStart: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Adds engine-level prescribed-run matching via findPrescribedRun() with structured outcomes (no_week, no_prescribed_run, ambiguous).
- Adds CLI --prescribed-run selector support:
  - YYYY-MM-DD / date:YYYY-MM-DD -> date override
  - label:<label> / bare text -> label override
  - clear validation errors for malformed/blank values.
- Adds override-mode fallback: with --prescribed-run and no --plan, CLI tries ./plan.yaml; if missing, errors with guidance to use --plan <path>.
- Preserves existing no-override auto-discovery behavior.
- Adds tests for selector parsing, fallback/error paths, and integration behavior.
- Adds prescribedRunContext in analysis output when association succeeds.

## Notes/Risks
- Matching is exact by design (no fuzzy label matching).
- Association walks the plan each invocation (fine for current sizes).
- planContext and prescribedRunContext can legitimately diverge/independently exist.