### PR TITLE
 Adds renders prescription comparison in output

### DIFF
--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/64-render-prescription-comparison-output/aar.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/64-render-prescription-comparison-output/aar.md
@@ -1,0 +1,10 @@
+1. Did it go as planned? Yes -- the formatter section gate, profile wiring,
+   and Markdown/JSON/YAML exposure for `prescriptionComparison` landed with
+   behavior-level tests and passing repository test/build checks.
+2. What changed from the sub-issue plan: Markdown rendering was implemented as
+   a factual section with run-level evidence plus per-step status rows, and the
+   comparison block remains isolated from split-column filtering and
+   `skipSegmentsIfSingleLap` behavior.
+3. Carry-forward -- flags to write in the parent, divergence to note for future
+   siblings, notes for the parent issue's AAR: No new sibling flags. Parent #63
+   appears closure-ready after parent-level AAR completion.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/64-render-prescription-comparison-output/sub-issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/64-render-prescription-comparison-output/sub-issue.md
@@ -1,0 +1,238 @@
+# Sub-Issue #64 -- Render Prescription Comparison Output
+
+Vertical slice for parent #63. Delivers the formatter section, profile handling,
+and Markdown/JSON/YAML exposure for `AnalysisResult.prescriptionComparison`.
+
+## Description
+
+Add `prescription_comparison` as an Output Profile section and render existing
+single-Run Prescription Comparison data in every supported output format. JSON
+and YAML should preserve the engine's structured comparison contract so tests
+and future history lookup can consume it directly. Markdown should present the
+same evidence in a runner-readable section without adding coaching conclusions.
+
+Out of scope: comparable-history lookup, prior-Run deltas, detailed-profile
+artifact validation, YAML-vs-JSON history precedence, FIT lap comparison logic,
+Plan schema changes, and new CLI flags.
+
+## Dependency classification
+
+| Dependency                                                                 | Category   | Testing strategy                                                                                                                    |
+| -------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `AnalysisResult.prescriptionComparison` and `PrescriptionComparison` types | In-process | Build typed formatter fixtures with available and unavailable comparisons; assert formatter output preserves the contract.          |
+| Output Profile section filtering                                           | In-process | Call `formatResult` with default, explicit include, and explicit exclude profiles; assert section visibility follows profile state. |
+| Config schema section validation                                           | In-process | Parse config fixtures containing `prescription_comparison` under default and detailed profiles.                                     |
+| Markdown formatter                                                         | In-process | Assert factual headings, context, unavailable reasons, and representative row evidence from small fixtures.                         |
+| JSON and YAML formatters                                                   | In-process | Parse formatter output back into objects and assert structured fields instead of comparing prose.                                   |
+| Existing Segment and column filtering                                      | In-process | Use formatter tests to assert `skipSegmentsIfSingleLap` and active columns do not remove or mutate Prescription Comparison.         |
+
+No local-substitutable, remote-owned, collaborator-owned, true external, or
+irreplaceable dependency is introduced. No port is needed because formatting is
+an in-process transformation over `AnalysisResult` data with no alternate
+adapter boundary.
+
+## Interface design
+
+The interface this sub-issue commits to is the formatter-facing section contract
+for Prescription Comparison.
+
+### Design-it-twice
+
+**Alternative A -- Minimal section pass-through**
+
+Add `prescription_comparison` to the section vocabulary. When active, pass
+`AnalysisResult.prescriptionComparison` through the existing filtered result and
+let each formatter render it.
+
+```ts
+export type SectionId = ExistingSectionId | "prescription_comparison";
+
+formatResult(result, format, {
+  sections: ["summary", "prescription_comparison"],
+  columns: "all",
+});
+```
+
+- Leverage: high -- the existing profile and formatter dispatch seams do the
+  routing with one new section.
+- Locality: high -- changes stay in formatter types, config schema, formatter
+  filtering, and formatter tests.
+- Testability: high -- fixture AnalysisResults can exercise all output states
+  without FIT files or Plan parsing.
+
+**Alternative B -- Common-caller always-on comparison output**
+
+Forward `prescriptionComparison` whenever it exists, similar to current Plan
+Context forwarding, and do not add a profile section.
+
+```ts
+interface FilteredResult {
+  planContext?: PlanContext;
+  prescriptionComparison?: PrescriptionComparison;
+}
+```
+
+- Leverage: medium -- default runner output is simple and hard to misconfigure.
+- Locality: high -- it avoids config-schema changes.
+- Testability: medium -- tests are simple, but future detailed-artifact checks
+  cannot distinguish intentional section inclusion from always-on metadata.
+
+**Alternative C -- Strongest runner encounter presentation model**
+
+Create a dedicated presentation model that groups warmup, work reps, recoveries,
+and cooldowns, summarizes only the most important rows in Markdown, and emits a
+separate normalized JSON/YAML shape optimized for repeated-session review.
+
+```ts
+export interface PrescriptionComparisonPresentation {
+  heading: string;
+  status: "available" | "unavailable";
+  summaryRows: PrescriptionComparisonSummaryRow[];
+  stepRows: PrescriptionComparisonDisplayRow[];
+}
+```
+
+- Leverage: medium -- Markdown could be more polished for repeated interval
+  review.
+- Locality: low -- a second comparison shape risks drifting from the engine
+  contract and history artifact needs.
+- Testability: medium -- presentation tests would grow separately from
+  structured comparison tests.
+
+### Choice
+
+**A (minimal section pass-through).** It exposes the existing structured
+Prescription Comparison through the established Output Profile seam with the
+smallest new surface.
+
+B is rejected in one sentence: always-on output bypasses the Output Profile term
+and makes future detailed-artifact eligibility harder to reason about. C is
+rejected in one sentence: a presentation model would duplicate the comparison
+contract before history work proves a second shape is needed.
+
+### Public interface
+
+Entry point:
+
+```ts
+formatResult(result, format, profile);
+```
+
+Inputs:
+
+- `result.prescriptionComparison`: optional `PrescriptionComparison` from parent
+  #60.
+- `profile.sections`: optional `SectionId[]` that may include
+  `prescription_comparison`.
+- `format`: existing `"markdown" | "json" | "yaml"` output selector.
+
+Outputs:
+
+- Markdown includes a `Prescription Comparison` section only when
+  `prescription_comparison` is active and `result.prescriptionComparison`
+  exists.
+- JSON includes `prescriptionComparison` only when active and present.
+- YAML includes `prescription_comparison` only when active and present.
+- Formatter warnings continue to report only existing profile and capability
+  warnings unless an existing code path already produces one.
+
+Invariants:
+
+- The formatter does not mutate `AnalysisResult.prescriptionComparison`.
+- The formatter does not re-associate a Run, reparse Prescription Notation,
+  recompute Segments, or derive Target Ranges from Zones.
+- Available and unavailable comparison status values are preserved exactly.
+- JSON keeps camelCase keys because current JSON formatter output is camelCase.
+- YAML keeps snake_case keys because current YAML formatter output applies
+  `camelToSnake`.
+- Column filtering affects Segment and Km Split rows, not Prescription
+  Comparison evidence.
+- `skipSegmentsIfSingleLap` affects only the Segment section, not Prescription
+  Comparison visibility.
+
+Error modes:
+
+- Missing `result.prescriptionComparison` produces no section and no warning.
+- An excluded `prescription_comparison` section produces no section and no
+  warning.
+- Unknown section IDs remain config-schema validation failures through the
+  existing config parser.
+
+## Acceptance criteria
+
+- `SectionId`, config `SECTION_IDS`, and `DEFAULT_PROFILE.sections` include
+  `prescription_comparison`.
+- `applyProfile` forwards `prescriptionComparison` only when the section is
+  active and present on `AnalysisResult`.
+- Markdown output renders available Prescription Comparison data with a heading,
+  Prescribed Run label/date, match kind, optional Comparison Group, run-level
+  actual evidence, and one row per step.
+- Markdown step rows include Prescribed Step index/source, target kind, actual
+  completion value, delta, completion status, power status, and available heart
+  rate/pace evidence.
+- Markdown output renders unavailable Prescription Comparison data with heading,
+  Prescribed Run label/date, reason, prescribed step count, and actual Segment
+  count.
+- JSON output includes `prescriptionComparison` for available and unavailable
+  fixture results when the section is active.
+- YAML output includes `prescription_comparison` for available and unavailable
+  fixture results when the section is active.
+- Runs without `prescriptionComparison` omit the section in Markdown, JSON, and
+  YAML without warnings.
+- Profiles that exclude `prescription_comparison` omit the section even when the
+  result has comparison data.
+- Existing Segment, Km Split, Plan Context, capability warning, and column
+  filtering behavior remains unchanged except for expected snapshots that now
+  include the default section when comparison data exists.
+- No history artifact reader, prior-Run delta computation, Plan parser change,
+  FIT parser change, or new CLI option is introduced.
+- Repository-runnable verification commands pass at closure, including
+  `pnpm test` and `pnpm build`.
+
+## Proposed tests
+
+1. **Config accepts section** -- parsing config with `prescription_comparison`
+   in `output.default.sections` and `output.detailed.sections` succeeds.
+2. **Default profile includes section** -- formatting a result with comparison
+   data and `DEFAULT_PROFILE` emits the section.
+3. **Profile exclusion hides section** -- formatting with
+   `sections: ["summary"]` omits comparison data in Markdown, JSON, and YAML.
+4. **Absent comparison omits section** -- a normal AnalysisResult without
+   `prescriptionComparison` emits no empty comparison block and no warning.
+5. **JSON available shape** -- JSON output for an available comparison contains
+   `prescriptionComparison.status`, `prescribedRun`, `actual`, and `steps`.
+6. **JSON unavailable shape** -- JSON output for an unavailable comparison
+   contains `reason`, `prescribedStepCount`, and `actualSegmentCount`.
+7. **YAML available shape** -- YAML output for an available comparison contains
+   `prescription_comparison.status`, `prescribed_run`, `actual`, and `steps`.
+8. **YAML unavailable shape** -- YAML output for an unavailable comparison
+   contains `reason`, `prescribed_step_count`, and `actual_segment_count`.
+9. **Markdown available section** -- Markdown output includes the heading,
+   Prescribed Run context, run-level actuals, and representative step evidence.
+10. **Markdown unavailable section** -- Markdown output includes the heading,
+    unavailable reason and counts, and no fabricated step table.
+11. **Single-lap skip isolation** -- `skipSegmentsIfSingleLap` may skip the
+    Segment section but does not hide Prescription Comparison.
+12. **Column filtering isolation** -- active columns do not remove completion or
+    power evidence from Prescription Comparison rows.
+
+## Affected artifacts
+
+- `packages/engine/src/types.ts`
+- `packages/engine/src/config/schema.ts`
+- `packages/engine/src/config/schema.test.ts`
+- `packages/engine/src/formatters/index.ts`
+- `packages/engine/src/formatters/markdown.ts`
+- `packages/engine/src/formatters/json.ts`
+- `packages/engine/src/formatters/yaml.ts`
+- `packages/engine/src/formatters/index.test.ts`
+- Existing formatter snapshots or fixture helpers, if any test output changes
+  because `DEFAULT_PROFILE` now includes `prescription_comparison`.
+
+## Dependencies
+
+- Parent #60 must remain closed because this sub-issue consumes its
+  `PrescriptionComparison` contract without changing comparison semantics.
+- Existing formatter profile filtering must remain the only section-gating seam.
+- Future comparable-history work depends on this sub-issue exposing structured
+  YAML/JSON comparison data but is not implemented here.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/issue.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/issue.md
@@ -1,0 +1,98 @@
+# Parent Issue #63 -- Prescription Comparison Output
+
+> Technical execution doc. Sub-issues live in sibling `XX-...` folders.
+
+## Acceptance criteria
+
+- The formatter layer treats Prescription Comparison as an Output Profile
+  section named `prescription_comparison`.
+- The default Output Profile includes `prescription_comparison` so a matched
+  Prescribed Run appears in normal Markdown, JSON, and YAML output without a
+  custom profile.
+- Config parsing accepts `prescription_comparison` in `output.default.sections`
+  and `output.detailed.sections`.
+- Profile filtering forwards `AnalysisResult.prescriptionComparison` only when
+  the section is active and the result has comparison data. Runs without an
+  associated Prescribed Run continue to omit the section.
+- JSON output exposes the structured comparison as `prescriptionComparison` and
+  preserves the available and unavailable result shapes from the engine
+  contract.
+- YAML output exposes the structured comparison as `prescription_comparison` and
+  preserves the same data after the existing snake-case conversion.
+- Markdown output renders a factual `Prescription Comparison` section for
+  available comparisons with the Prescribed Run label/date, match kind,
+  Comparison Group when present, run-level actual evidence, and per-step
+  prescribed-vs-actual completion and power evidence.
+- Markdown output renders unavailable comparisons with the Prescribed Run
+  label/date, reason, prescribed step count, and actual Segment count. It does
+  not fabricate partial rows for `missing_laps` or `step_count_mismatch`.
+- Formatter output does not re-run Prescribed Run association, reparse
+  Prescription Notation, recompute Segments, infer lap boundaries, or look up
+  current Zone values for Target Ranges.
+- Existing profile behavior remains intact: `skipSegmentsIfSingleLap` affects
+  only the Segment section, column filtering affects Segment and Km Split rows,
+  and Plan Context remains forwarded according to existing rules.
+- Structured formatter tests cover JSON and YAML available output, JSON and YAML
+  unavailable output, Markdown available output, Markdown unavailable output,
+  section exclusion, default-profile inclusion, absent comparison data, and
+  config schema acceptance of `prescription_comparison`.
+- Repository-runnable verification commands succeed at parent closure, including
+  `pnpm test` and `pnpm build`.
+
+## Implementation approach
+
+1. Extend the formatter section vocabulary with `prescription_comparison` in the
+   engine `SectionId` type, config schema, default profile, and formatter
+   section dispatch.
+2. Add `prescriptionComparison` to the filtered formatter result only when the
+   profile includes `prescription_comparison` and `AnalysisResult` carries the
+   field.
+3. Emit the existing structured `PrescriptionComparison` object in JSON and YAML
+   without deriving a second shape. Let the existing YAML key-case conversion
+   produce `prescription_comparison` and snake-case nested keys.
+4. Add a Markdown renderer that presents available comparison evidence as
+   factual rows and unavailable comparison as a short status block. Keep prose
+   stable but do not make Markdown the only assertion surface.
+5. Add formatter and config-schema tests before implementation. Prefer small
+   typed `AnalysisResult` fixtures over FIT fixtures because parent #60 already
+   tested `quantify` integration.
+6. Avoid history artifact readers, prior-Run lookup, same-basename artifact
+   rules, and detailed-profile eligibility checks. Those belong to the next
+   history parent after output exposure is closed.
+
+This parent is expected to close in one vertical slice because the section ID,
+profile filtering, and three formatter outputs must agree for the Analysis
+Artifact surface to be useful downstream.
+
+## Dependencies
+
+- Upstream: parent #60 provides the `PrescriptionComparison` contract and
+  attaches it to `AnalysisResult` when a Prescribed Run comparison exists.
+- Upstream: existing formatter separation provides `formatResult`, Markdown,
+  JSON, YAML, profile filtering, and config-schema section validation.
+- Downstream: comparable-history deltas consume saved detailed YAML/JSON
+  Analysis Artifacts and decide detailed-profile eligibility, key-case
+  normalization, missing/partial artifact reasons, and YAML-vs-JSON ambiguity
+  behavior.
+- External: no new persistence layer, database, cache, external service, Plan
+  schema change, FIT parsing change, Zone subsystem change, or CLI flag.
+- Tooling: use repository-defined commands only. Existing `pnpm test` and
+  `pnpm build` scripts are sufficient for parent closure.
+
+## Flags
+
+- This parent exposes current single-Run Prescription Comparison only. It does
+  not produce prior-Run deltas or read historical Analysis Artifacts.
+- The Output Profile section name is `prescription_comparison` to match existing
+  snake-case section IDs such as `km_splits`, `hr_zones`, and `pace_zones`.
+- JSON keeps the repository's existing camelCase output convention; YAML keeps
+  the existing snake_case conversion convention.
+- `skipSegmentsIfSingleLap` must not hide Prescription Comparison. A one-step
+  comparison remains visible even if the Segment table is skipped.
+- The cycle PRD's detailed-profile validation question remains open for the
+  history parent. This parent only ensures the structured section can exist in
+  YAML/JSON Analysis Artifacts.
+- [x] [64-render-prescription-comparison-output](64-render-prescription-comparison-output/sub-issue.md) -- closed with formatter/profile/config updates, tests, and `pnpm test` + `pnpm build` passing.
+
+  Render `AnalysisResult.prescriptionComparison` through Markdown, JSON, and
+  YAML formatters behind the `prescription_comparison` Output Profile section.

--- a/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/sub-prd.md
+++ b/context/cycles/02-run-prescriptions-and-comparisons/issues/63-prescription-comparison-output/sub-prd.md
@@ -1,0 +1,75 @@
+# Parent Issue #63 -- Prescription Comparison Output
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## Scope
+
+Expose the structured single-Run Prescription Comparison from parent #60 through
+Run2Max's user-facing output formats. Markdown should give the runner readable
+evidence, while JSON and YAML should preserve a structured section that tests
+and future history lookup can consume without scraping prose.
+
+This parent owns formatter and Output Profile exposure only. It does not read
+prior Analysis Artifacts, compute comparable-history deltas, choose YAML-vs-JSON
+history precedence, or add new comparison metrics.
+
+## Owned user stories
+
+From the cycle PRD:
+
+- As a runner quantifying a FIT File from a planned interval day, I see whether
+  the captured lap sequence matched the Prescribed Run, so I can review the Run
+  against what I intended to execute.
+- As a maintainer adding the feature, I can test formatting through structured
+  data, so output wording changes do not break the behavior contract.
+
+This parent does not own the comparable-history story. It makes the current
+Run's Prescription Comparison visible in saved output so the later history
+parent has a stable Analysis Artifact surface to inspect.
+
+## Encounter statements affecting this scope
+
+- A runner running `run2max quantify path/to/run.fit --plan . --format yaml`
+  first encounters normal AnalysisResult sections plus a structured
+  `prescription_comparison` section when a matching Prescribed Run exists.
+- A runner reading Markdown output sees a factual Prescription Comparison
+  section that names the Prescribed Run, reports available or unavailable
+  status, and shows step evidence without coaching conclusions.
+- A maintainer opening formatter code first sees the Prescription Comparison
+  treated as an AnalysisResult section, not as a recomputation of association,
+  lap matching, or Target Range logic.
+
+## Directional dependencies on other sub-PRDs
+
+- Upstream: closed parent #53 provides Prescribed Run and Prescribed Step data,
+  including inline Target Ranges preserved from Prescription Notation.
+- Upstream: closed parent #59 provides `prescribedRunContext` on AnalysisResult
+  when a Run is associated with one intended Prescribed Run.
+- Upstream: closed parent #60 provides `AnalysisResult.prescriptionComparison`
+  with available and unavailable states for single-Run comparison.
+- Downstream: comparable-history deltas consume saved detailed YAML/JSON
+  Analysis Artifacts that may include the structured Prescription Comparison
+  exposed here.
+- Downstream: history artifact validation still owns detailed-profile
+  eligibility, missing-artifact and partial-artifact reasons, and same-basename
+  YAML/JSON ambiguity rules.
+
+## Domain language
+
+No new domain terms are introduced. This parent uses existing glossary terms:
+**Quantify**, **AnalysisResult**, **Analysis Artifact**, **Output Profile**,
+**Prescription Comparison**, **Prescribed Run**, **Prescribed Step**, **Target
+Range**, **Run**, **FIT File**, **Segment**, **Comparison Group**, and **RPE**.
+
+Boundary scenarios checked against `context/ubiquitous-language.md`:
+
+- A rendered Markdown section is output for a **Prescription Comparison**; it is
+  not a new comparison engine and must not alter the structured comparison
+  rules.
+- JSON and YAML outputs are **Analysis Artifacts** only when saved by the
+  runner; this parent formats the data but does not decide historical
+  eligibility.
+- An **Output Profile** may include or exclude the **Prescription Comparison**
+  section, but default runner-facing output should expose it when present.

--- a/packages/engine/src/config/schema.test.ts
+++ b/packages/engine/src/config/schema.test.ts
@@ -135,7 +135,7 @@ describe("parseConfig", () => {
       ...minimalConfig,
       output: {
         default: {
-          sections: ["summary", "elevation_profile", "weather", "hr_zones", "pace_zones", "metadata"],
+          sections: ["summary", "elevation_profile", "weather", "hr_zones", "pace_zones", "prescription_comparison", "metadata"],
         },
       },
     });
@@ -143,6 +143,7 @@ describe("parseConfig", () => {
     expect(result.output?.default?.sections).toContain("weather");
     expect(result.output?.default?.sections).toContain("hr_zones");
     expect(result.output?.default?.sections).toContain("pace_zones");
+    expect(result.output?.default?.sections).toContain("prescription_comparison");
     expect(result.output?.default?.sections).toContain("metadata");
   });
 

--- a/packages/engine/src/config/schema.ts
+++ b/packages/engine/src/config/schema.ts
@@ -24,6 +24,7 @@ const SECTION_IDS = [
   "weather",
   "hr_zones",
   "pace_zones",
+  "prescription_comparison",
   "metadata",
 ] as const;
 

--- a/packages/engine/src/formatters/index.test.ts
+++ b/packages/engine/src/formatters/index.test.ts
@@ -167,6 +167,81 @@ function buildResult(overrides?: Partial<AnalysisResult>): AnalysisResult {
   };
 }
 
+function buildAvailableComparison(): NonNullable<AnalysisResult["prescriptionComparison"]> {
+  return {
+    status: "available",
+    prescribedRun: {
+      label: "4x5min",
+      localDate: "2026-04-12",
+      comparisonGroup: "threshold_5min",
+      matchKind: "date",
+      weekNumber: 4,
+      weekType: "L",
+    },
+    actual: {
+      duration: 7402,
+      distance: 18080,
+      avgPower: 224,
+      avgHeartRate: 140,
+      maxHeartRate: 165,
+      avgPace: 409,
+      rpe: 2,
+    },
+    steps: [
+      {
+        index: 0,
+        prescribed: {
+          source: "5min@SUB-T",
+          target: { kind: "duration", value: 300, unit: "seconds" },
+          intensityLabel: "SUB-T",
+          targetRange: { metric: "power", min: 289, max: 301, unit: "W" },
+        },
+        actual: {
+          lapIndex: 0,
+          distance: 1510,
+          duration: 300,
+          avgPower: 295,
+          avgHeartRate: 155,
+          avgPace: 238,
+        },
+        completion: {
+          targetKind: "duration",
+          prescribedValue: 300,
+          actualValue: 300,
+          delta: 0,
+          ratio: 1,
+          status: "within_tolerance",
+          tolerance: { lower: 285, upper: 315 },
+        },
+        power: {
+          status: "within",
+          actualAvgPower: 295,
+          targetRange: { metric: "power", min: 289, max: 301, unit: "W" },
+          deltaToMin: 6,
+          deltaToMax: -6,
+        },
+      },
+    ],
+  };
+}
+
+function buildUnavailableComparison(): NonNullable<AnalysisResult["prescriptionComparison"]> {
+  return {
+    status: "unavailable",
+    reason: "step_count_mismatch",
+    prescribedRun: {
+      label: "4x5min",
+      localDate: "2026-04-12",
+      comparisonGroup: "threshold_5min",
+      matchKind: "date",
+      weekNumber: 4,
+      weekType: "L",
+    },
+    prescribedStepCount: 8,
+    actualSegmentCount: 7,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -185,6 +260,7 @@ describe("formatResult", () => {
         "zones",
         "dynamics",
         "anomalies",
+        "prescription_comparison",
         "metadata",
       ]);
     });
@@ -372,6 +448,30 @@ describe("formatResult", () => {
       const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
       expect(output).toContain("224 W (E)");
     });
+
+    it("renders available prescription comparison section with run and step evidence", () => {
+      const result = buildResult({ prescriptionComparison: buildAvailableComparison() });
+      const { output } = formatResult(result, "markdown", DEFAULT_PROFILE);
+
+      expect(output).toContain("## Prescription Comparison");
+      expect(output).toContain("Prescribed Run: 4x5min (2026-04-12)");
+      expect(output).toContain("Match Kind: date");
+      expect(output).toContain("Comparison Group: threshold_5min");
+      expect(output).toContain("Actual Run:");
+      expect(output).toContain("5min@SUB-T");
+      expect(output).toContain("within_tolerance");
+      expect(output).toContain("within");
+    });
+
+    it("renders unavailable prescription comparison without a fabricated step table", () => {
+      const result = buildResult({ prescriptionComparison: buildUnavailableComparison() });
+      const { output } = formatResult(result, "markdown", DEFAULT_PROFILE);
+
+      expect(output).toContain("## Prescription Comparison");
+      expect(output).toContain("Status: unavailable (step_count_mismatch)");
+      expect(output).toContain("Counts: Prescribed Steps 8 | Actual Segments 7");
+      expect(output).not.toContain("| Prescribed Step | Source | Target Kind");
+    });
   });
 
   // ─── PROFILE FILTERING: SECTIONS ──────────────────────────────────────────
@@ -391,6 +491,19 @@ describe("formatResult", () => {
       const profile = { ...DEFAULT_PROFILE, sections: ["summary"] as SectionId[] };
       const { output } = formatResult(buildResult(), "markdown", profile);
       expect(output).not.toContain("## Metadata");
+    });
+
+    it("hides prescription comparison when section is excluded", () => {
+      const profile = { ...DEFAULT_PROFILE, sections: ["summary"] as SectionId[] };
+      const result = buildResult({ prescriptionComparison: buildAvailableComparison() });
+
+      const markdown = formatResult(result, "markdown", profile).output;
+      const json = JSON.parse(formatResult(result, "json", profile).output) as Record<string, unknown>;
+      const yaml = parseYaml(formatResult(result, "yaml", profile).output) as Record<string, unknown>;
+
+      expect(markdown).not.toContain("## Prescription Comparison");
+      expect(json["prescriptionComparison"]).toBeUndefined();
+      expect(yaml["prescription_comparison"]).toBeUndefined();
     });
 
     it("includes ## Metadata when metadata is in sections", () => {
@@ -579,11 +692,60 @@ describe("formatResult", () => {
       const { output } = formatResult(buildResult(), "markdown", DEFAULT_PROFILE);
       expect(output).toContain("## Workout Splits");
     });
+
+    it("does not hide prescription comparison when segments are skipped", () => {
+      const profile = { ...DEFAULT_PROFILE, skipSegmentsIfSingleLap: true };
+      const result = buildResult({
+        segments: [buildResult().segments[0]!],
+        prescriptionComparison: buildAvailableComparison(),
+      });
+      const { output } = formatResult(result, "markdown", profile);
+
+      expect(output).not.toContain("## Workout Splits");
+      expect(output).toContain("## Prescription Comparison");
+    });
   });
 
   // ─── JSON FORMAT ──────────────────────────────────────────────────────────
 
   describe("json format", () => {
+    it("includes prescriptionComparison in default JSON output when comparison data exists", () => {
+      const result = buildResult({
+        prescriptionComparison: buildAvailableComparison(),
+      });
+
+      const { output } = formatResult(result, "json", DEFAULT_PROFILE);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+
+      expect(parsed["prescriptionComparison"]).toBeDefined();
+    });
+
+    it("preserves available prescription comparison shape", () => {
+      const result = buildResult({ prescriptionComparison: buildAvailableComparison() });
+      const { output } = formatResult(result, "json", DEFAULT_PROFILE);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const comparison = parsed["prescriptionComparison"] as Record<string, unknown>;
+      const actual = comparison["actual"] as Record<string, unknown>;
+      const steps = comparison["steps"] as Array<Record<string, unknown>>;
+
+      expect(comparison["status"]).toBe("available");
+      expect(comparison["prescribedRun"]).toBeDefined();
+      expect(actual["avgPower"]).toBe(224);
+      expect(steps).toHaveLength(1);
+    });
+
+    it("preserves unavailable prescription comparison shape", () => {
+      const result = buildResult({ prescriptionComparison: buildUnavailableComparison() });
+      const { output } = formatResult(result, "json", DEFAULT_PROFILE);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const comparison = parsed["prescriptionComparison"] as Record<string, unknown>;
+
+      expect(comparison["status"]).toBe("unavailable");
+      expect(comparison["reason"]).toBe("step_count_mismatch");
+      expect(comparison["prescribedStepCount"]).toBe(8);
+      expect(comparison["actualSegmentCount"]).toBe(7);
+    });
+
     it("produces valid JSON", () => {
       const { output } = formatResult(buildResult(), "json", DEFAULT_PROFILE);
       expect(() => JSON.parse(output)).not.toThrow();
@@ -670,6 +832,58 @@ describe("formatResult", () => {
       const parsed = parseYaml(output) as Record<string, unknown>;
       expect(parsed["summary"]).toBeDefined();
       expect(parsed["segments"]).toBeUndefined();
+    });
+
+    it("includes snake_case prescription_comparison for available shape", () => {
+      const result = buildResult({ prescriptionComparison: buildAvailableComparison() });
+      const { output } = formatResult(result, "yaml", DEFAULT_PROFILE);
+      const parsed = parseYaml(output) as Record<string, unknown>;
+      const comparison = parsed["prescription_comparison"] as Record<string, unknown>;
+
+      expect(comparison["status"]).toBe("available");
+      expect(comparison["prescribed_run"]).toBeDefined();
+      expect(comparison["actual"]).toBeDefined();
+      expect(comparison["steps"]).toBeDefined();
+    });
+
+    it("includes snake_case unavailable fields in prescription_comparison", () => {
+      const result = buildResult({ prescriptionComparison: buildUnavailableComparison() });
+      const { output } = formatResult(result, "yaml", DEFAULT_PROFILE);
+      const parsed = parseYaml(output) as Record<string, unknown>;
+      const comparison = parsed["prescription_comparison"] as Record<string, unknown>;
+
+      expect(comparison["status"]).toBe("unavailable");
+      expect(comparison["reason"]).toBe("step_count_mismatch");
+      expect(comparison["prescribed_step_count"]).toBe(8);
+      expect(comparison["actual_segment_count"]).toBe(7);
+    });
+
+    it("omits prescription comparison when result has no comparison data", () => {
+      const { output: jsonOutput } = formatResult(buildResult(), "json", DEFAULT_PROFILE);
+      const { output: yamlOutput } = formatResult(buildResult(), "yaml", DEFAULT_PROFILE);
+
+      const parsedJson = JSON.parse(jsonOutput) as Record<string, unknown>;
+      const parsedYaml = parseYaml(yamlOutput) as Record<string, unknown>;
+
+      expect(parsedJson["prescriptionComparison"]).toBeUndefined();
+      expect(parsedYaml["prescription_comparison"]).toBeUndefined();
+    });
+  });
+
+  describe("prescription comparison isolation", () => {
+    it("does not depend on active split columns", () => {
+      const result = buildResult({ prescriptionComparison: buildAvailableComparison() });
+      const profile = {
+        ...DEFAULT_PROFILE,
+        columns: ["power"] as ColumnId[],
+      };
+      const { output } = formatResult(result, "markdown", profile);
+
+      expect(output).toContain("## Prescription Comparison");
+      expect(output).toContain("Completion");
+      expect(output).toContain("Power");
+      expect(output).toContain("within_tolerance");
+      expect(output).toContain("within");
     });
   });
 });

--- a/packages/engine/src/formatters/index.ts
+++ b/packages/engine/src/formatters/index.ts
@@ -7,6 +7,7 @@ import type {
   FormatResult,
   OutputFormat,
   PlanContext,
+  PrescriptionComparison,
   RunSummary,
   SegmentRow,
   KmSplitRow,
@@ -28,7 +29,7 @@ import { formatYaml } from "./yaml.js";
 // ---------------------------------------------------------------------------
 
 export const DEFAULT_PROFILE: OutputProfileConfig = {
-  sections: ["summary", "elevation_profile", "weather", "segments", "km_splits", "zones", "dynamics", "anomalies", "metadata"],
+  sections: ["summary", "elevation_profile", "weather", "segments", "km_splits", "zones", "dynamics", "anomalies", "prescription_comparison", "metadata"],
   columns: "all",
   skipSegmentsIfSingleLap: true,
 };
@@ -59,6 +60,7 @@ interface FilteredResult {
   anomalies?: Anomaly[];
   /** Periodization context — always passed through when present on AnalysisResult. */
   planContext?: PlanContext;
+  prescriptionComparison?: PrescriptionComparison;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,7 +112,7 @@ function applyProfile(
 ): { filtered: FilteredResult; activeSections: SectionId[]; warnings: string[] } {
   const allSections: SectionId[] = [
     "summary", "elevation_profile", "weather", "segments", "km_splits",
-    "zones", "hr_zones", "pace_zones", "dynamics", "anomalies", "metadata",
+    "zones", "hr_zones", "pace_zones", "dynamics", "anomalies", "prescription_comparison", "metadata",
   ];
   let activeSections: SectionId[] = profile.sections ?? allSections;
   const warnings: string[] = [];
@@ -145,6 +147,9 @@ function applyProfile(
   if (activeSections.includes("pace_zones"))  filtered.paceZoneDistribution = result.paceZoneDistribution;
   if (activeSections.includes("dynamics"))    filtered.dynamicsSummary = result.dynamicsSummary;
   if (activeSections.includes("anomalies"))   filtered.anomalies = result.anomalies;
+  if (activeSections.includes("prescription_comparison") && result.prescriptionComparison) {
+    filtered.prescriptionComparison = result.prescriptionComparison;
+  }
 
   return { filtered, activeSections, warnings };
 }

--- a/packages/engine/src/formatters/json.ts
+++ b/packages/engine/src/formatters/json.ts
@@ -54,6 +54,7 @@ export function formatJson(
   if (filtered.dynamicsSummary !== undefined)  out["dynamicsSummary"] = filtered.dynamicsSummary;
   if (filtered.anomalies !== undefined)        out["anomalies"] = filtered.anomalies;
   if (filtered.planContext !== undefined)      out["planContext"] = filtered.planContext;
+  if (filtered.prescriptionComparison !== undefined) out["prescriptionComparison"] = filtered.prescriptionComparison;
 
   return JSON.stringify(out, null, 2);
 }

--- a/packages/engine/src/formatters/markdown.ts
+++ b/packages/engine/src/formatters/markdown.ts
@@ -320,6 +320,80 @@ function renderAnomalies(result: FilteredResult): string {
   return ["## Anomalies", "", ...items].join("\n");
 }
 
+function formatCompletionValue(targetKind: "distance" | "duration", value: number): string {
+  return targetKind === "distance" ? fmtDistance(value) : fmtDuration(value);
+}
+
+function formatCompletionDelta(targetKind: "distance" | "duration", delta: number): string {
+  const sign = delta >= 0 ? "+" : "";
+  return targetKind === "distance"
+    ? `${sign}${(delta / 1000).toFixed(2)} km`
+    : `${sign}${Math.round(delta)} s`;
+}
+
+function renderPrescriptionComparison(result: FilteredResult): string {
+  const comparison = result.prescriptionComparison;
+  if (!comparison) return "";
+
+  const lines: string[] = ["## Prescription Comparison", ""];
+  lines.push(`Prescribed Run: ${comparison.prescribedRun.label} (${comparison.prescribedRun.localDate})`);
+  lines.push(`Match Kind: ${comparison.prescribedRun.matchKind}`);
+  if (comparison.prescribedRun.comparisonGroup) {
+    lines.push(`Comparison Group: ${comparison.prescribedRun.comparisonGroup}`);
+  }
+
+  if (comparison.status === "unavailable") {
+    lines.push(`Status: unavailable (${comparison.reason})`);
+    lines.push(
+      `Counts: Prescribed Steps ${comparison.prescribedStepCount} | Actual Segments ${comparison.actualSegmentCount}`
+    );
+    return lines.join("\n");
+  }
+
+  const runActualParts = [
+    `Duration: ${fmtDuration(comparison.actual.duration)}`,
+    `Distance: ${fmtDistance(comparison.actual.distance)}`,
+    `Avg Power: ${comparison.actual.avgPower != null ? fmtPower(comparison.actual.avgPower) : NULL_PLACEHOLDER}`,
+    `Avg HR: ${comparison.actual.avgHeartRate != null ? fmtHR(comparison.actual.avgHeartRate) : NULL_PLACEHOLDER}`,
+    `Avg Pace: ${comparison.actual.avgPace != null ? fmtPace(comparison.actual.avgPace) : NULL_PLACEHOLDER}`,
+  ];
+  if (comparison.actual.maxHeartRate != null) {
+    runActualParts.push(`Max HR: ${fmtHR(comparison.actual.maxHeartRate)}`);
+  }
+  if (comparison.actual.rpe != null) {
+    runActualParts.push(`RPE: ${comparison.actual.rpe}`);
+  }
+  lines.push(`Actual Run: ${runActualParts.join(" | ")}`);
+  lines.push("");
+
+  const headers = [
+    "Prescribed Step",
+    "Source",
+    "Target Kind",
+    "Actual Completion",
+    "Delta",
+    "Completion",
+    "Power",
+    "Avg HR",
+    "Avg Pace",
+  ];
+
+  const rows = comparison.steps.map((step) => [
+    `${step.index + 1} (lap ${step.actual.lapIndex + 1})`,
+    step.prescribed.source,
+    step.completion.targetKind,
+    formatCompletionValue(step.completion.targetKind, step.completion.actualValue),
+    formatCompletionDelta(step.completion.targetKind, step.completion.delta),
+    step.completion.status,
+    step.power.status,
+    step.actual.avgHeartRate != null ? fmtHR(step.actual.avgHeartRate) : NULL_PLACEHOLDER,
+    step.actual.avgPace != null ? fmtPace(step.actual.avgPace) : NULL_PLACEHOLDER,
+  ]);
+
+  lines.push(padTable(headers, rows));
+  return lines.join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // Plan context header (always rendered above sections when present)
 // ---------------------------------------------------------------------------
@@ -361,6 +435,7 @@ const SECTION_RENDERERS: Record<
   pace_zones:        (r) => renderPaceZones(r),
   dynamics:          (r) => renderDynamics(r),
   anomalies:         (r) => renderAnomalies(r),
+  prescription_comparison: (r) => renderPrescriptionComparison(r),
   metadata:          (r) => renderMetadata(r),
 };
 

--- a/packages/engine/src/formatters/yaml.ts
+++ b/packages/engine/src/formatters/yaml.ts
@@ -55,6 +55,7 @@ export function formatYaml(
   if (filtered.dynamicsSummary !== undefined)  out["dynamicsSummary"] = filtered.dynamicsSummary;
   if (filtered.anomalies !== undefined)        out["anomalies"] = filtered.anomalies;
   if (filtered.planContext !== undefined)      out["planContext"] = filtered.planContext;
+  if (filtered.prescriptionComparison !== undefined) out["prescriptionComparison"] = filtered.prescriptionComparison;
 
   return stringify(camelToSnake(out));
 }

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -375,6 +375,7 @@ export type SectionId =
   | "weather"
   | "hr_zones"
   | "pace_zones"
+  | "prescription_comparison"
   | "metadata";
 
 export type ColumnId =


### PR DESCRIPTION
Exposes single-Run Prescription Comparison through Markdown, JSON, and YAML
formatters behind the `prescription_comparison` Output Profile section.


- Adds `prescription_comparison` to `SectionId`, config schema validation, and
  `DEFAULT_PROFILE.sections` so comparisons appear out of the box.
- `applyProfile` forwards `result.prescriptionComparison` only when the section
  is active and data exists.
- JSON and YAML pass through the structured `PrescriptionComparison` contract
  unchanged (camelCase / snake_case per existing conventions).
- Markdown renders available comparisons with Prescribed Run context, run-level
  actuals, and per-step completion/power evidence; unavailable comparisons show
  reason and counts without fabricating rows.
- `skipSegmentsIfSingleLap` and column filtering do not affect comparison output.
- Updated engine/CLI READMEs with the new section.

Closes #63 , Closes #64 